### PR TITLE
Renamed crates and filter out features staring with "__"

### DIFF
--- a/src/cargo_metadata.rs
+++ b/src/cargo_metadata.rs
@@ -23,16 +23,17 @@ fn fetch_cargo_metadata_json() -> Result<String, Box<dyn error::Error>> {
 #[derive(Clone)]
 pub struct Dependency {
     pub name: String,
+    pub rename: Option<String>,
     pub optional: bool,
 }
 
 impl From<json::JsonValue> for Dependency {
     fn from(json_value: json::JsonValue) -> Self {
         let name = json_value["name"].as_str().unwrap().to_owned();
-
+        let rename = json_value["rename"].as_str().map(|s| s.to_string());
         let optional = json_value["optional"].as_bool().unwrap();
 
-        Dependency { name, optional }
+        Dependency { name, rename, optional }
     }
 }
 

--- a/src/features_finder.rs
+++ b/src/features_finder.rs
@@ -36,6 +36,8 @@ fn fetch_features(package: &crate::cargo_metadata::Package) -> Vec<String> {
         .features
         .iter()
         .filter(|key| key != &"default")
+        // Some crates use "__" to indicate internal features
+        .filter(|key| !key.starts_with("__"))
         .cloned()
         .collect()
 }

--- a/src/features_finder.rs
+++ b/src/features_finder.rs
@@ -21,7 +21,13 @@ fn fetch_optional_dependencies(package: &crate::cargo_metadata::Package) -> Vec<
         .dependencies
         .iter()
         .filter(|dependency| dependency.optional)
-        .map(|dependency| dependency.name.to_string())
+        .map(|dependency| {
+            if let Some(name) = &dependency.rename {
+                name.to_string()
+            } else {
+                dependency.name.to_string()
+            }
+        })
         .collect()
 }
 


### PR DESCRIPTION
Two issues found while trying to get this crate to work with `reqwest` crate:

 * Add support for renamed dependencies. For example `reqwest` has renamed `cookie` to `cookie_crate`. See https://github.com/seanmonstar/reqwest/blob/dbd887c262a47cdda8a4a006a53a330eb0ddab6a/Cargo.toml#L103

 * Filter out features which start with double underscore (`__`). This might not be standardized convention in cargo, but commonly used naming scheme in many programming languages, etc. See https://github.com/seanmonstar/reqwest/blob/dbd887c262a47cdda8a4a006a53a330eb0ddab6a/Cargo.toml#L55-L62