### PR TITLE
Add options to cargo-all-features in Cargo.toml metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ cargo test-all-features <CARGO TEST FLAGS>
 
 If you have a crate that utilizes Rust feature flags, it’s common to set up a test matrix in your continuous integration tooling to _individually_ test all feature flags. This setup can be difficult to maintain and easy to forget to update as feature flags come and go. It’s also not exhaustive, as it’s possible enabling _combinations_ of feature flags could result in a compilation error that should be fixed. This utility was built to address these concerns.
 
+## Options
+
+You can add the following options to your Cargo.toml file to configure the behavior of cargo-all-features under the heading `[package.metadata.cargo-all-features]`:
+
+```toml
+[package.metadata.cargo-all-features]
+
+# Features "foo" and "bar" are incompatible, so skip permutations including them
+skip_feature_sets = [
+    ["foo", "bar"],
+]
+
+# If your crate has a large number of optional dependencies, skip them for speed
+skip_optional_dependencies = true
+
+# Add back certain optional dependencies that you want to include in the permutations
+extra_features = [
+    "log",
+]
+```
+
 ## License
 
 Licensed under either of

--- a/src/cargo_metadata.rs
+++ b/src/cargo_metadata.rs
@@ -44,6 +44,9 @@ pub struct Package {
     pub manifest_path: path::PathBuf,
     pub dependencies: Vec<Dependency>,
     pub features: Vec<String>,
+    pub skip_feature_sets: Vec<Vec<String>>,
+    pub skip_optional_dependencies: bool,
+    pub extra_features: Vec<String>,
 }
 
 impl From<json::JsonValue> for Package {
@@ -60,6 +63,28 @@ impl From<json::JsonValue> for Package {
             .entries()
             .map(|(k, _v)| k.to_owned())
             .collect();
+        let skip_feature_sets: Vec<Vec<String>> = json_value["metadata"]
+            ["cargo-all-features"]
+            ["skip_feature_sets"]
+            .members()
+            .map(|member| {
+                member
+                    .members()
+                    .map(|feature| feature.as_str().unwrap().to_owned())
+                    .collect()
+            })
+            .collect();
+        let skip_optional_dependencies: bool = json_value["metadata"]
+            ["cargo-all-features"]
+            ["skip_optional_dependencies"]
+            .as_bool()
+            .unwrap_or(false);
+        let extra_features: Vec<String> = json_value["metadata"]
+            ["cargo-all-features"]
+            ["extra_features"]
+            .members()
+            .map(|member| member.as_str().unwrap().to_owned())
+            .collect();
 
         Package {
             id,
@@ -67,6 +92,9 @@ impl From<json::JsonValue> for Package {
             manifest_path,
             dependencies,
             features,
+            skip_feature_sets,
+            skip_optional_dependencies,
+            extra_features,
         }
     }
 }


### PR DESCRIPTION
I added some settings that projects can put in their Cargo.toml to customize the behavior of cargo-all-features.

CC @echeran