### PR TITLE
Add --help arguments to the binaries for smoke testing

### DIFF
--- a/src/bin/cargo-build-all-features.rs
+++ b/src/bin/cargo-build-all-features.rs
@@ -1,5 +1,12 @@
+use std::env;
 use std::error;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
+    if let Some(arg) = env::args().skip(1).next() {
+        if arg == "--help" {
+            println!("See https://crates.io/crates/cargo-all-features");
+            return Ok(());
+        }
+    }
     cargo_all_features::run(cargo_all_features::test_runner::CargoCommand::Build)
 }

--- a/src/bin/cargo-test-all-features.rs
+++ b/src/bin/cargo-test-all-features.rs
@@ -1,5 +1,12 @@
+use std::env;
 use std::error;
 
 fn main() -> Result<(), Box<dyn error::Error>> {
+    if let Some(arg) = env::args().skip(1).next() {
+        if arg == "--help" {
+            println!("See https://crates.io/crates/cargo-all-features");
+            return Ok(());
+        }
+    }
     cargo_all_features::run(cargo_all_features::test_runner::CargoCommand::Test)
 }


### PR DESCRIPTION
[cargo make](https://github.com/sagiegurari/cargo-make#crates) needs to be able to run a command to check whether or not a crate is installed.  It typically does this by running `command --help`.  I added a stub `--help` to the binaries in this crate so that they can be used with cargo make.

CC @echeran