### PR TITLE
update rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-all-features"
 version = "1.6.0"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
-edition = "2018"
+edition = "2021"
 description = "A Cargo subcommand to build and test all feature flag combinations"
 repository = "https://github.com/frewsxcv/cargo-all-features"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
I ran `cargo fix --edition` and it didn't find any problems. So it should be good to go.