### PR TITLE
Fix #39: permit building only root package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "cargo-all-features"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "itertools",
  "json",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Test crate with all feature flag combinations:
 cargo test-all-features <CARGO TEST FLAGS>
 ```
 
+Test just the [root
+crate](https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package)
+in a workspace, rather than every crate.
+
+```(shell)
+cargo test-all-features --root-only <CARGO TEST FLAGS>
+```
+
 
 ## Why?
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,17 +6,24 @@ pub mod test_runner;
 mod types;
 
 pub fn run(cargo_command: test_runner::CargoCommand) -> Result<(), Box<dyn error::Error>> {
-    if let Some(arg) = env::args().nth(1) {
-        if arg == "--help" {
-            println!("See https://crates.io/crates/cargo-all-features");
-            return Ok(());
+    let (root_only, args) = if let Some(arg) = env::args().nth(2) {
+        match &arg[..] {
+            "--help" => {
+                println!("See https://crates.io/crates/cargo-all-features");
+                return Ok(());
+            }
+            "--root-only" => (true, env::args().skip(3)),
+            _ => (false, env::args().skip(2)),
         }
-    }
+    } else {
+        (false, env::args().skip(2))
+    };
+    let args = args.collect::<Vec<_>>();
 
-    let packages = determine_packages_to_test()?;
+    let packages = determine_packages_to_test(root_only)?;
 
     for package in packages {
-        let outcome = test_all_features_for_package(&package, cargo_command)?;
+        let outcome = test_all_features_for_package(&package, cargo_command, &args)?;
 
         if let TestOutcome::Fail(exit_status) = outcome {
             process::exit(exit_status.code().unwrap());
@@ -29,6 +36,7 @@ pub fn run(cargo_command: test_runner::CargoCommand) -> Result<(), Box<dyn error
 fn test_all_features_for_package(
     package: &cargo_metadata::Package,
     command: crate::test_runner::CargoCommand,
+    args: &[String],
 ) -> Result<TestOutcome, Box<dyn error::Error>> {
     let feature_sets = crate::features_finder::fetch_feature_sets(package);
 
@@ -42,6 +50,7 @@ fn test_all_features_for_package(
                 .parent()
                 .expect("could not find parent of cargo manifest path")
                 .to_owned(),
+            args,
         );
 
         let outcome = test_runner.run()?;
@@ -56,11 +65,13 @@ fn test_all_features_for_package(
     Ok(TestOutcome::Pass)
 }
 
-fn determine_packages_to_test() -> Result<Vec<cargo_metadata::Package>, Box<dyn error::Error>> {
+fn determine_packages_to_test(
+    root_only: bool,
+) -> Result<Vec<cargo_metadata::Package>, Box<dyn error::Error>> {
     let current_dir = env::current_dir()?;
     let metadata = cargo_metadata::fetch()?;
 
-    Ok(if current_dir == metadata.workspace_root {
+    Ok(if !root_only && current_dir == metadata.workspace_root {
         metadata
             .packages
             .iter()

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -1,5 +1,5 @@
 use crate::types::FeatureList;
-use std::{env, error, path, process};
+use std::{error, path, process};
 use termcolor::WriteColor;
 
 pub struct TestRunner {
@@ -17,6 +17,7 @@ impl TestRunner {
         crate_name: String,
         feature_set: FeatureList,
         working_dir: path::PathBuf,
+        args: &[String],
     ) -> Self {
         let mut command = process::Command::new(&crate::cargo_cmd());
 
@@ -39,7 +40,7 @@ impl TestRunner {
         }
 
         // Pass through cargo args
-        for arg in env::args().skip(2) {
+        for arg in args.iter() {
             command.arg(&arg);
         }
 


### PR DESCRIPTION
At the root dir of Cargo workspaces are either a virtual manifest, or a root package. For root packages, we cannot rely on the heuristic of being in a particular sub-dir to locate a single package to run. The new option `--root-only` selects the single-package logic in this case.