### PR TITLE
Add support for arbitrary cargo subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,6 @@ repository = "https://github.com/frewsxcv/cargo-all-features"
 license = "MIT/Apache-2.0"
 readme = "./README.md"
 
-[[bin]]
-name = "cargo-build-all-features"
-path = "src/bin/cargo-build-all-features.rs"
-
-[[bin]]
-name = "cargo-test-all-features"
-path = "src/bin/cargo-test-all-features.rs"
-
 [dependencies]
 json = "0.12"
 itertools = "0.10"

--- a/README.md
+++ b/README.md
@@ -32,12 +32,34 @@ Test crate with all feature flag combinations:
 cargo test-all-features <CARGO TEST FLAGS>
 ```
 
+To run another cargo subcommand (i.e. `clippy`, `miri`, etc.) with all feature flag combinations:
+
+```
+cargo all-features <CARGO SUBCOMMAND> <CARGO FLAGS>
+```
+For example, to run Clippy with all feature flag combinations:
+
+```
+cargo all-features clippy <CARGO CLIPPY FLAGS>
+```
 
 ## Why?
 
 If you have a crate that utilizes Rust feature flags, it’s common to set up a test matrix in your continuous integration tooling to _individually_ test all feature flags. This setup can be difficult to maintain and easy to forget to update as feature flags come and go. It’s also not exhaustive, as it’s possible enabling _combinations_ of feature flags could result in a compilation error that should be fixed. This utility was built to address these concerns.
 
 ## Options
+
+### Command line options
+
+- `--n-chunks` and `--chunks`:  
+  The project supports chunking. `--n-chunks 3 --chunks 1` will split the crates being tested into three sets (alphabetically, currently), and run the requested command for the first set of crates only. This is useful for splitting up CI jobs or performing disk cleanups since for large workspaces `check-all-features` and friends can take a very long time and produce a ton of artifacts.
+- `--feature-flags-last`:  
+  The project uses the `--no-default-features` and `--features` flags of cargo to select the features to use when building/testing/etc. Usually, those flags are put before the provided `<CARGO FLAGS>`, causing tools such as `miri` to not work with cargo-all-features. Using this option, feature selection flags will be put after `<CARGO FLAGS>`. Thus, for example, it's possible to call `miri` using:
+  ```
+  cargo all-features --feature-flags-last miri test <OTHER MIRI FLAGS>
+  ```
+
+### Other options
 
 You can add the following options to your Cargo.toml file to configure the behavior of cargo-all-features under the heading `[package.metadata.cargo-all-features]`:
 
@@ -74,8 +96,6 @@ max_combination_size = 4
 #(incompatible with `denylist`, `skip_optional_dependencies`, and `extra_features`)
 allowlist = ["foo", "bar"]
 ```
-
-The project also supports chunking: `--n-chunks 3 --chunks 1` will split the crates being tested into three sets (alphabetically, currently), and run the requested command for the first set of crates only. This is useful for splitting up CI jobs or performing disk cleanups since for large workspaces `check-all-features` and friends can take a very long time and produce a ton of artifacts.
 
 ## License
 

--- a/src/bin/cargo-all-features.rs
+++ b/src/bin/cargo-all-features.rs
@@ -1,0 +1,6 @@
+use cargo_all_features::run;
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    run(None)
+}

--- a/src/bin/cargo-build-all-features.rs
+++ b/src/bin/cargo-build-all-features.rs
@@ -2,5 +2,5 @@ use cargo_all_features::{run, test_runner::CargoCommand};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    run(CargoCommand::Build)
+    run(Some(CargoCommand::Build))
 }

--- a/src/bin/cargo-check-all-features.rs
+++ b/src/bin/cargo-check-all-features.rs
@@ -2,5 +2,5 @@ use cargo_all_features::{run, test_runner::CargoCommand};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    run(CargoCommand::Check)
+    run(Some(CargoCommand::Check))
 }

--- a/src/bin/cargo-test-all-features.rs
+++ b/src/bin/cargo-test-all-features.rs
@@ -2,5 +2,5 @@ use cargo_all_features::{run, test_runner::CargoCommand};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    run(CargoCommand::Test)
+    run(Some(CargoCommand::Test))
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -15,30 +15,24 @@ impl<'a> TestRunner<'a> {
     pub fn new<'b: 'a>(
         cargo_command: &'b str,
         crate_name: String,
+        feature_flags_last: bool,
         feature_set: FeatureList,
         cargo_args: &[String],
         working_dir: path::PathBuf,
     ) -> Self {
         let mut command = process::Command::new(&crate::cargo_cmd());
 
-        command.arg("--no-default-features");
-
-        let mut features = feature_set
-            .iter()
-            .fold(String::new(), |s, feature| s + feature + ",");
-
-        if !features.is_empty() {
-            features.remove(features.len() - 1);
-
-            command.arg("--features");
-            command.arg(&features);
-        }
-
-        // Pass through cargo args
-        for arg in cargo_args {
-            command.arg(arg);
-        }
         command.arg(cargo_command);
+
+        // Put feature arguments as last only if feature_flags_last is true to retain backwards compatibility
+        let features;
+        if feature_flags_last {
+            TestRunner::add_cargo_args(&mut command, cargo_args);
+            features = TestRunner::add_features(&mut command, &feature_set);
+        } else {
+            features = TestRunner::add_features(&mut command, &feature_set);
+            TestRunner::add_cargo_args(&mut command, cargo_args);
+        }
 
         TestRunner {
             crate_name,
@@ -74,6 +68,29 @@ impl<'a> TestRunner<'a> {
         } else {
             crate::TestOutcome::Fail(output.status)
         })
+    }
+
+    fn add_features(command: &mut process::Command, feature_set: &FeatureList) -> String {
+        command.arg("--no-default-features");
+
+        let mut features = feature_set
+        .iter()
+        .fold(String::new(), |s, feature| s + feature + ",");
+
+        if !features.is_empty() {
+            features.remove(features.len() - 1);
+
+            command.arg("--features");
+            command.arg(&features);
+        }
+
+        features
+    }
+
+    fn add_cargo_args(command: &mut process::Command, cargo_args: &[String]) {
+        for arg in cargo_args {
+            command.arg(arg);
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the `all-features` subcommand to allow cargo-all-features to work with arbitrary cargo subcommands like Clippy and Miri.

**Syntax:**
```
cargo all-features <CARGO SUBCOMMAND> <CARGO FLAGS>
```
<br>

This also adds the `--feature-flags-last` flag to better support tools which requires a subcommand, like Miri. The flag makes cargo-all-features to put feature-related flags (`--no-default-features` and `--features`) after the additional cargo flags passed by the user. Thus, for example, to call Miri one could run `cargo all-features --feature-flags-last miri test <OTHER MIRI FLAGS>`.  
The old binaries haven't been removed.

Fixes #5
Fixes #15
Fixes #26