### PR TITLE
Integration tests, refactoring, and powerful feature rule expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,18 +61,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f070617a68e5c2ed5d06ee8dd620ee18fb72b99f6c094bed34cf8ab07c875b48"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "bstr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8042c26c77e5bd6897a7358e0abb3ec412ed126d826988135653fc669263899d"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "cargo-all-features"
 version = "1.9.0"
 dependencies = [
+ "assert_cmd",
+ "assert_fs",
  "clap",
  "itertools",
  "json",
+ "predicates",
+ "regex",
  "termcolor",
 ]
 
@@ -72,6 +138,12 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -121,6 +193,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +232,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +287,23 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "is-terminal"
@@ -186,6 +332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,10 +350,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memchr"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "predicates"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -222,17 +432,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "regex"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
 name = "rustix"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 
 [[package]]
 name = "strsim"
@@ -252,12 +515,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -271,6 +563,25 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +137,9 @@ dependencies = [
  "clap",
  "itertools",
  "json",
+ "lazy_static",
+ "pest",
+ "pest_derive",
  "predicates",
  "regex",
  "termcolor",
@@ -193,10 +205,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "doc-comment"
@@ -251,6 +292,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "globset"
@@ -383,6 +434,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "pest"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "predicates"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +594,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 
 [[package]]
+name = "sha2"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +650,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "thiserror"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +678,18 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-ident"
@@ -563,6 +702,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,9 @@ json = "0.12"
 itertools = "0.10"
 termcolor = "1"
 clap = { version = "4.3.19", features = ["derive"] }
+
+[dev-dependencies]
+assert_cmd = "2.0.11"
+predicates = "3.0.3"
+assert_fs = "1.0.13"
+regex = "1.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ json = "0.12"
 itertools = "0.10"
 termcolor = "1"
 clap = { version = "4.3.19", features = ["derive"] }
+pest = "2.7.3"
+pest_derive = "2.7.3"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.11"

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ extra_features = [
 denylist = ["foo", "bar"]
 
 # Always include these features in combinations.
-# These features should not be included in `skip_feature_sets` or `denylist`, they get
-# added in later
+# These features should not be included in `denylist`
 always_include_features = ["baz"]
 
 # The maximum number of features to try at once. Does not count features from `always_include_features`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ max_combination_size = 4
 # Only include certain features in the build matrix
 #(incompatible with `denylist`, and `extra_features`)
 allowlist = ["foo", "bar"]
+
+# Specify rules through expressions using logical operators !, &, ^, |, <=>, =>,
+# and summation +, -, >=, <=, >, <, == (in order of high to low precedence)
+# Every selected feature set will fullfill ALL specified rules.
+rules = [
+    "A + B + C == 1",  # exactly one of the three features A, B, C is enabled
+    "A + B + C >= 1",  # at least one of the three is enabled
+    "A => (B|C)",  # if package A is enabled, at least one of B or C needs to be enabled too
+    "'foo-bar'",  # the feature set must contain feature foo-bar, use '' quotation for feature names with hyphens
+    """((A => (B|C)) <=> (A+C==1)) \
+    | !'foo-bar_baz' """,  # expressions can be arbitrarily nested
+    "!(A | B | C)",  # equivalent to denylist = [A, B, C]
+    "A & B & C",  # equivalent to always_include_features = [A, B, C]
+    "!(A & B & C)",  # equivalent to skip_feature_sets containing [A, B, C]
+]
 ```
 
 The project also supports chunking: `--n-chunks 3 --chunks 1` will split the crates being tested into three sets (alphabetically, currently), and run the requested command for the first set of crates only. This is useful for splitting up CI jobs or performing disk cleanups since for large workspaces `check-all-features` and friends can take a very long time and produce a ton of artifacts.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ always_include_features = ["baz"]
 max_combination_size = 4
 
 # Only include certain features in the build matrix
-#(incompatible with `denylist`, `skip_optional_dependencies`, and `extra_features`)
+#(incompatible with `denylist`, and `extra_features`)
 allowlist = ["foo", "bar"]
 ```
 

--- a/ci/test_and_coverage.bash
+++ b/ci/test_and_coverage.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $SCRIPT_DIR/..
+
+rm target/profraw/cargo-test-*.profraw
+CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='target/profraw/cargo-test-%p-%m.profraw' cargo test
+
+rm -rf target/coverage
+grcov target/profraw/. --binary-path ./target/debug/ -s . -t html --branch --ignore-not-existing -o target/coverage/html
+
+popd

--- a/src/cargo_metadata.rs
+++ b/src/cargo_metadata.rs
@@ -44,6 +44,14 @@ impl From<json::JsonValue> for Dependency {
     }
 }
 
+fn parse_json_into_feature(val: &json::JsonValue) -> Feature {
+    Feature(val.to_string())
+}
+
+fn parse_json_into_feature_list(val: &json::JsonValue) -> FeatureList {
+    val.members().map(parse_json_into_feature).collect()
+}
+
 #[derive(Clone)]
 pub struct Package {
     pub id: String,
@@ -64,6 +72,7 @@ pub struct Package {
 impl TryFrom<json::JsonValue> for Package {
     type Error = String;
     fn try_from(json_value: json::JsonValue) -> Result<Self, String> {
+        let json_value_settings = &json_value["metadata"]["cargo-all-features"];
         let id = json_value["id"].as_str().unwrap().to_owned();
         let name = json_value["name"].as_str().unwrap().to_owned();
         let manifest_path =
@@ -79,53 +88,23 @@ impl TryFrom<json::JsonValue> for Package {
             .collect();
         let feature_map = json_value["features"]
             .entries()
-            .map(|(k, v)| {
-                (
-                    k.to_owned(),
-                    FeatureList(v.members().map(|v| Feature(v.to_string())).collect()),
-                )
-            })
+            .map(|(k, v)| (k.to_owned(), parse_json_into_feature_list(v)))
             .collect();
-        let skip_feature_sets: Vec<FeatureList> = json_value["metadata"]["cargo-all-features"]
-            ["skip_feature_sets"]
+        let skip_feature_sets: Vec<FeatureList> = json_value_settings["skip_feature_sets"]
             .members()
-            .map(|member| {
-                member
-                    .members()
-                    .map(|feature| feature.as_str().unwrap().to_owned())
-                    .map(Feature)
-                    .collect()
-            })
+            .map(parse_json_into_feature_list)
             .collect();
-        let maybe_skip_optional =
-            json_value["metadata"]["cargo-all-features"]["skip_optional_dependencies"].as_bool();
-        let skip_optional_dependencies: bool = maybe_skip_optional.unwrap_or(false);
-        let extra_features: FeatureList = json_value["metadata"]["cargo-all-features"]
-            ["extra_features"]
+        let maybe_skip_optional = json_value_settings["skip_optional_dependencies"].as_bool();
+        let skip_optional_dependencies = maybe_skip_optional.unwrap_or(false);
+        let extra_features = parse_json_into_feature_list(&json_value_settings["extra_features"]);
+        let allowlist = parse_json_into_feature_list(&json_value_settings["allowlist"]);
+        let denylist: HashSet<_> = json_value_settings["denylist"]
             .members()
-            .map(|member| member.as_str().unwrap().to_owned())
-            .map(Feature)
+            .map(parse_json_into_feature)
             .collect();
-
-        let allowlist: FeatureList = json_value["metadata"]["cargo-all-features"]["allowlist"]
-            .members()
-            .map(|member| member.as_str().unwrap().to_owned())
-            .map(Feature)
-            .collect();
-
-        let denylist: HashSet<_> = json_value["metadata"]["cargo-all-features"]["denylist"]
-            .members()
-            .map(|member| member.as_str().unwrap().to_owned())
-            .map(Feature)
-            .collect();
-        let always_include_features: FeatureList = json_value["metadata"]["cargo-all-features"]
-            ["always_include_features"]
-            .members()
-            .map(|member| member.as_str().unwrap().to_owned())
-            .map(Feature)
-            .collect();
-        let max_combination_size =
-            json_value["metadata"]["cargo-all-features"]["max_combination_size"].as_usize();
+        let always_include_features =
+            parse_json_into_feature_list(&json_value_settings["always_include_features"]);
+        let max_combination_size = json_value_settings["max_combination_size"].as_usize();
 
         if !allowlist.is_empty() {
             if !always_include_features.is_empty() {

--- a/src/cargo_metadata.rs
+++ b/src/cargo_metadata.rs
@@ -125,12 +125,6 @@ impl TryFrom<json::JsonValue> for Package {
                     name
                 ));
             }
-            if maybe_skip_optional.is_some() {
-                return Err(format!(
-                    "Package {} has both `allowlist` and `skip_optional_dependencies` keys",
-                    name
-                ));
-            }
             if max_combination_size.is_some() {
                 return Err(format!(
                     "Package {} has both `allowlist` and `max_combination_size` keys",

--- a/src/cargo_metadata.rs
+++ b/src/cargo_metadata.rs
@@ -135,16 +135,6 @@ impl TryFrom<json::JsonValue> for Package {
 
         if !always_include_features.is_empty() {
             let always: HashSet<_> = always_include_features.iter().collect();
-            for set in &skip_feature_sets {
-                for feature in set.iter() {
-                    if always.contains(&feature) {
-                        return Err(format!(
-                            "Package {} has feature {} in both `skip_feature_sets` and `always_include_features`",
-                            name, &**feature
-                        ));
-                    }
-                }
-            }
             for feature in denylist.iter() {
                 if always.contains(&feature) {
                     return Err(format!(

--- a/src/cargo_metadata.rs
+++ b/src/cargo_metadata.rs
@@ -66,6 +66,7 @@ pub struct Package {
     pub denylist: HashSet<Feature>,
     pub extra_features: FeatureList,
     pub always_include_features: FeatureList,
+    pub rules: Vec<String>,
     pub max_combination_size: Option<usize>,
 }
 
@@ -104,6 +105,10 @@ impl TryFrom<json::JsonValue> for Package {
             .collect();
         let always_include_features =
             parse_json_into_feature_list(&json_value_settings["always_include_features"]);
+        let rules = json_value_settings["rules"]
+            .members()
+            .map(|val| val.to_string())
+            .collect();
         let max_combination_size = json_value_settings["max_combination_size"].as_usize();
 
         if !allowlist.is_empty() {
@@ -158,6 +163,7 @@ impl TryFrom<json::JsonValue> for Package {
             allowlist,
             denylist,
             always_include_features,
+            rules,
             max_combination_size,
         })
     }

--- a/src/features_finder.rs
+++ b/src/features_finder.rs
@@ -1,130 +1,109 @@
 use crate::{
     cargo_metadata::Dependency,
+    rules::{new_rule, Expr},
     types::{Feature, FeatureList},
 };
 use itertools::Itertools;
 use std::collections::HashSet;
 
+type NamedRule = (String, Expr);
+
 pub fn fetch_feature_sets(package: &crate::cargo_metadata::Package) -> Vec<FeatureList> {
-    let mut features = FeatureList::default();
-
-    let mut denylist_and_alwayses = package.denylist.clone();
-    denylist_and_alwayses.extend(package.always_include_features.iter().cloned());
-
-    let filter_denylist_and_alwayses = |f: &Feature| !denylist_and_alwayses.contains(f);
-
-    let mut implicit_features = HashSet::<&str>::new();
-    let mut optional_dep_used_with_dep_syntax_outside_of_implicit_feature = HashSet::new();
-
-    for (feature, implied_features) in &package.feature_map {
-        if implied_features.len() == 1 && implied_features[0] == "dep:".to_owned() + feature {
-            // Feature of the shape foo = ["dep:foo"]
-            implicit_features.insert(feature);
-        } else {
-            for implied_dep in implied_features
-                .iter()
-                .filter_map(|v| v.strip_prefix("dep:"))
-            {
-                optional_dep_used_with_dep_syntax_outside_of_implicit_feature.insert(implied_dep);
-            }
-        }
-    }
-
-    // If the dep is used with `dep:` syntax in another feature,
-    // it's an explicit feature, because cargo wouldn't generate
-    // the implicit feature.
-    for x in &optional_dep_used_with_dep_syntax_outside_of_implicit_feature {
-        implicit_features.remove(x);
-    }
-
-    let optional_dependencies = fetch_optional_dependencies(package)
-        .filter(filter_denylist_and_alwayses)
-        .filter(|f: &Feature| {
-            !optional_dep_used_with_dep_syntax_outside_of_implicit_feature.contains(f.0.as_str())
-        });
+    let mut features = HashSet::new();
 
     if package.allowlist.is_empty() {
-        if !package.skip_optional_dependencies {
-            features.extend(optional_dependencies);
-        }
-
-        features.extend(
-            fetch_features(package)
-                .filter(filter_denylist_and_alwayses)
-                .filter(|f: &Feature| !implicit_features.contains(f.0.as_str())),
-        );
-
-        features.extend(
-            package
-                .extra_features
-                .iter()
-                .cloned()
-                .filter(filter_denylist_and_alwayses),
-        );
+        features.extend(fetch_optional_dependencies(package));
+        features.extend(fetch_features(package));
+        features.extend(package.extra_features.iter().cloned());
     } else {
-        // allowlist cannot be mixed with denylist or any of the other above options,
-        // no need to filter
-        if package.skip_optional_dependencies {
-            let optional_dependencies: Vec<_> = optional_dependencies.collect();
-            features.extend(
-                package
-                    .allowlist
-                    .iter()
-                    .cloned()
-                    .filter(|f| !optional_dependencies.contains(f)),
-            );
-        } else {
-            features.extend(package.allowlist.iter().cloned());
-        }
-    };
+        features.extend(package.allowlist.iter().cloned());
+    }
+    features.extend(package.always_include_features.iter().cloned());
 
-    let mut feature_sets = vec![];
+    let mut named_rules: Vec<NamedRule> = vec![];
+    for (feature, implied_features) in &package.feature_map {
+        if implied_features.len() == 0 {
+            continue;
+        }
+        let rule_name = format!("implication:{}", feature);
+        let implied_features: Vec<_> = implied_features
+            .iter()
+            .map(|f| Feature(f.0.strip_prefix("dep:").unwrap_or(&f.0[..]).to_owned()))
+            .filter(|f| features.contains(f))
+            .collect();
+        if let Some(rule) = new_rule::implication(
+            FeatureList(vec![Feature(feature.to_owned())]).iter(),
+            implied_features.iter(),
+        ) {
+            named_rules.push((rule_name, rule));
+        }
+    }
+    if package.skip_optional_dependencies {
+        let denied_opt_deps: Vec<_> = fetch_optional_dependencies(package)
+            .filter(|dep| !package.extra_features.contains(dep))
+            .collect();
+        if let Some(rule) = new_rule::not_any(denied_opt_deps.iter()) {
+            named_rules.push(("skip_optional_dependencies".to_owned(), rule));
+        }
+    }
+    if let Some(rule) = new_rule::not_any(package.denylist.iter()) {
+        named_rules.push(("denylist".to_owned(), rule));
+    }
+    if let Some(rule) = new_rule::all(package.always_include_features.iter()) {
+        named_rules.push(("always_include_features".to_owned(), rule));
+    }
+    for conflict in package.skip_feature_sets.iter() {
+        named_rules.push((
+            format!(
+                "conflict:{}",
+                conflict.iter().map(|f| f.0.clone()).join(",")
+            ),
+            new_rule::not_all(conflict.iter()).unwrap(),
+        ));
+    }
 
     let max_combination_size = package.max_combination_size.unwrap_or(features.len());
+    create_valid_feature_sets(&features, &named_rules, max_combination_size)
+}
+
+fn create_valid_feature_sets(
+    features: &HashSet<Feature>,
+    rules: &Vec<NamedRule>,
+    max_combination_size: usize,
+) -> Vec<FeatureList> {
+    let mut feature_sets = Vec::new();
     for n in 0..=max_combination_size {
         'outer: for feature_set in features.iter().combinations(n) {
-            let feature_set: HashSet<_> = feature_set
-                .into_iter()
-                .chain(package.always_include_features.iter())
-                .collect();
-            'inner: for skip_feature_set in &package.skip_feature_sets {
-                for feature in skip_feature_set.iter() {
-                    if !feature_set.contains(&feature) {
-                        // skip_feature_set does not match
-                        continue 'inner;
-                    }
-                }
-                // skip_feature_set matches: do not add it to feature_sets
-                continue 'outer;
-            }
-            for feat in feature_set.clone() {
-                // for mut dep in package.feature_map[&feat.0].iter().cloned() {
-                for mut dep in package
-                    .feature_map
-                    .get(&feat.0)
-                    .unwrap_or(&FeatureList::default())
-                    .iter()
-                    .cloned()
-                {
-                    if let Some(package_dep) = dep.strip_prefix("dep:") {
-                        if optional_dep_used_with_dep_syntax_outside_of_implicit_feature
-                            .contains(package_dep)
-                        {
-                            continue;
-                        } else {
-                            dep = Feature(package_dep.to_owned());
-                        }
-                    }
-                    if !feature_set.contains(&dep) {
-                        continue 'outer;
-                    }
+            let feature_set = HashSet::from_iter(feature_set);
+            for (_name, rule) in rules {
+                if !rule.eval(&feature_set).unwrap() {
+                    continue 'outer;
                 }
             }
             feature_sets.push(feature_set.into_iter().cloned().collect());
         }
     }
-
     feature_sets
+}
+
+fn create_implicit_feat_dependency_filter(
+    package: &crate::cargo_metadata::Package,
+) -> impl FnMut(&Feature) -> bool + '_ {
+    let mut explicit_deps: HashSet<&str> = HashSet::new();
+    for (feature, implied_features) in &package.feature_map {
+        if implied_features.len() == 1 && implied_features[0] == "dep:".to_owned() + feature {
+            // Feature of the shape foo = ["dep:foo"]
+            continue;
+        } else {
+            for implied_dep in implied_features
+                .iter()
+                .filter_map(|v| v.strip_prefix("dep:"))
+            {
+                explicit_deps.insert(implied_dep);
+            }
+        }
+    }
+    move |f| !explicit_deps.contains(&f[..])
 }
 
 fn fetch_optional_dependencies(
@@ -134,6 +113,7 @@ fn fetch_optional_dependencies(
         .dependencies
         .iter()
         .filter_map(Dependency::as_feature)
+        .filter(create_implicit_feat_dependency_filter(package))
 }
 
 fn fetch_features(package: &crate::cargo_metadata::Package) -> impl Iterator<Item = Feature> + '_ {

--- a/src/features_finder.rs
+++ b/src/features_finder.rs
@@ -17,14 +17,14 @@ pub fn fetch_feature_sets(package: &crate::cargo_metadata::Package) -> Vec<Featu
     let mut optional_dep_used_with_dep_syntax_outside_of_implicit_feature = HashSet::new();
 
     for (feature, implied_features) in &package.feature_map {
-        for implied_dep in implied_features
-            .iter()
-            .filter_map(|v| v.strip_prefix("dep:"))
-        {
-            if implied_features.len() == 1 && implied_dep == feature {
-                // Feature of the shape foo = ["dep:foo"]
-                implicit_features.insert(feature);
-            } else {
+        if implied_features.len() == 1 && implied_features[0] == "dep:".to_owned() + feature {
+            // Feature of the shape foo = ["dep:foo"]
+            implicit_features.insert(feature);
+        } else {
+            for implied_dep in implied_features
+                .iter()
+                .filter_map(|v| v.strip_prefix("dep:"))
+            {
                 optional_dep_used_with_dep_syntax_outside_of_implicit_feature.insert(implied_dep);
             }
         }

--- a/src/features_finder.rs
+++ b/src/features_finder.rs
@@ -83,6 +83,10 @@ pub fn fetch_feature_sets(package: &crate::cargo_metadata::Package) -> Vec<Featu
     let max_combination_size = package.max_combination_size.unwrap_or(features.len());
     for n in 0..=max_combination_size {
         'outer: for feature_set in features.iter().combinations(n) {
+            let feature_set: Vec<_> = feature_set
+                .into_iter()
+                .chain(package.always_include_features.iter())
+                .collect();
             'inner: for skip_feature_set in &package.skip_feature_sets {
                 for feature in skip_feature_set.iter() {
                     if !feature_set.contains(&feature) {
@@ -93,13 +97,7 @@ pub fn fetch_feature_sets(package: &crate::cargo_metadata::Package) -> Vec<Featu
                 // skip_feature_set matches: do not add it to feature_sets
                 continue 'outer;
             }
-            feature_sets.push(
-                feature_set
-                    .into_iter()
-                    .chain(package.always_include_features.iter())
-                    .cloned()
-                    .collect(),
-            );
+            feature_sets.push(feature_set.into_iter().cloned().collect());
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ fn test_all_features_for_package(
     command: crate::test_runner::CargoCommand,
     cargo_args: &[String],
 ) -> Result<TestOutcome, Box<dyn error::Error>> {
-    let feature_sets = crate::features_finder::fetch_feature_sets(package);
+    let feature_sets = crate::features_finder::fetch_feature_sets(package)?;
 
     for feature_set in feature_sets {
         let mut test_runner = crate::test_runner::TestRunner::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use std::{env, error, ffi, process};
 
 pub mod cargo_metadata;
 pub mod features_finder;
+pub mod rules;
 pub mod test_runner;
 mod types;
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,0 +1,122 @@
+pub use expr::Expr;
+
+mod expr;
+
+pub mod new_rule {
+    use super::expr::{Expr, InfixOp, Literal, PrefixOp};
+    use crate::types::Feature;
+
+    pub fn chain<'a, I>(op: InfixOp, features: I) -> Option<Expr>
+    where
+        I: IntoIterator<Item = &'a Feature>,
+    {
+        let mut features = features.into_iter();
+        let cur = features.next();
+        if let Some(cur) = cur {
+            let mut ans = Expr::Literal(Literal::Feature(cur.clone()));
+            for cur in features {
+                ans = ans.infix(op, Expr::Literal(Literal::Feature(cur.clone())));
+            }
+            Some(ans)
+        } else {
+            None
+        }
+    }
+
+    pub fn all<'a, I>(features: I) -> Option<Expr>
+    where
+        I: IntoIterator<Item = &'a Feature>,
+    {
+        chain(InfixOp::And, features)
+    }
+
+    pub fn not_all<'a, I>(features: I) -> Option<Expr>
+    where
+        I: IntoIterator<Item = &'a Feature>,
+    {
+        all(features).map(|expr| expr.prefix(PrefixOp::Not))
+    }
+
+    pub fn any<'a, I>(features: I) -> Option<Expr>
+    where
+        I: IntoIterator<Item = &'a Feature>,
+    {
+        chain(InfixOp::Or, features)
+    }
+
+    pub fn not_any<'a, I>(features: I) -> Option<Expr>
+    where
+        I: IntoIterator<Item = &'a Feature>,
+    {
+        any(features).map(|expr| expr.prefix(PrefixOp::Not))
+    }
+
+    pub fn implication<'a, I>(if_all: I, then_all: I) -> Option<Expr>
+    where
+        I: IntoIterator<Item = &'a Feature>,
+    {
+        let then_all = all(then_all);
+        if let Some(then_all) = then_all {
+            let if_all = all(if_all);
+            if let Some(if_all) = if_all {
+                Some(if_all.infix(InfixOp::Implies, then_all))
+            } else {
+                Some(then_all)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::new_rule;
+    use crate::types::{Feature, FeatureList};
+    use std::collections::HashSet;
+
+    #[test]
+    fn new_implication_rule() {
+        let if_all = vec![
+            Feature("A".to_owned()),
+            Feature("B".to_owned()),
+            Feature("C".to_owned()),
+        ];
+        let then_all = vec![Feature("D".to_owned()), Feature("E".to_owned())];
+        let mut all = if_all.clone();
+        all.extend(then_all.clone());
+        let implication_rule = new_rule::implication(
+            FeatureList(if_all.clone()).iter(),
+            FeatureList(then_all.clone()).iter(),
+        )
+        .unwrap();
+        for i in 0..(1 << all.len()) {
+            let mut select = HashSet::new();
+            for (j, a) in all.iter().enumerate() {
+                if (i >> j) & 1 == 1 {
+                    select.insert(a);
+                }
+            }
+            let mut if_all_covered = true;
+            for a in if_all.iter() {
+                if !select.contains(&a) {
+                    if_all_covered = false;
+                    break;
+                }
+            }
+            let mut then_all_covered = true;
+            for a in then_all.iter() {
+                if !select.contains(&a) {
+                    then_all_covered = false;
+                    break;
+                }
+            }
+            let decision = implication_rule.eval(&select).unwrap();
+            if if_all_covered {
+                assert!(decision == then_all_covered);
+            } else {
+                assert!(decision);
+            }
+        }
+    }
+}

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,10 +1,15 @@
 pub use expr::Expr;
 
 mod expr;
+mod parser;
 
 pub mod new_rule {
     use super::expr::{Expr, InfixOp, Literal, PrefixOp};
     use crate::types::Feature;
+
+    pub fn expr(expr: &str) -> Expr {
+        Expr::new(expr)
+    }
 
     pub fn chain<'a, I>(op: InfixOp, features: I) -> Option<Expr>
     where
@@ -68,7 +73,6 @@ pub mod new_rule {
         }
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::new_rule;

--- a/src/rules/expr.rs
+++ b/src/rules/expr.rs
@@ -1,0 +1,277 @@
+use crate::types::Feature;
+use std::{collections::HashSet, fmt::Debug, fmt::Display};
+
+pub enum Expr {
+    Literal(Literal),
+    Infix {
+        lhs: Box<Expr>,
+        op: InfixOp,
+        rhs: Box<Expr>,
+    },
+    Prefix {
+        op: PrefixOp,
+        rhs: Box<Expr>,
+    },
+}
+
+impl Expr {
+    pub fn infix(self, op: InfixOp, rhs: Self) -> Self {
+        Self::Infix {
+            lhs: Box::new(self),
+            op,
+            rhs: Box::new(rhs),
+        }
+    }
+
+    pub fn prefix(self, op: PrefixOp) -> Self {
+        Self::Prefix {
+            op,
+            rhs: Box::new(self),
+        }
+    }
+
+    fn evaluate(&self, feature_set: &HashSet<&Feature>) -> Result<ExprResult, String> {
+        match self {
+            Expr::Literal(Literal::Feature(name)) => {
+                Ok(ExprResult::Bool(feature_set.contains(name)))
+            }
+            Expr::Literal(Literal::Integer(int)) => Ok(ExprResult::Int(*int)),
+            Expr::Infix { lhs, op, rhs } => {
+                op.evaluate(lhs.evaluate(feature_set)?, rhs.evaluate(feature_set)?)
+            }
+            Expr::Prefix { op, rhs } => op.evaluate(rhs.evaluate(feature_set)?),
+        }
+    }
+
+    pub fn eval(&self, feature_set: &HashSet<&Feature>) -> Result<bool, String> {
+        let ans = self.evaluate(feature_set);
+        match ans {
+            Ok(ExprResult::Bool(b)) => Ok(b),
+            Ok(ExprResult::Int(i)) => Err(format!(
+                "provided rule returned integer {} instead of a boolean: {}",
+                i,
+                self.value_annotation_str(feature_set)
+            )),
+            Err(msg) => Err(format!(
+                "{}: {}",
+                msg,
+                self.value_annotation_str(feature_set)
+            )),
+        }
+    }
+
+    fn value_annotation_str(&self, feature_set: &HashSet<&Feature>) -> String {
+        let annotation = self.evaluate(feature_set);
+        let annotation = match annotation {
+            Ok(val) => format!("{}", val),
+            Err(_) => "ERR".to_owned(),
+        };
+        match self {
+            Expr::Literal(_) => format!("{}: {}", self, annotation),
+            Expr::Infix { lhs, op, rhs } => format!(
+                "({}) {} ({}): {}",
+                lhs.value_annotation_str(feature_set),
+                op,
+                rhs.value_annotation_str(feature_set),
+                annotation
+            ),
+            Expr::Prefix { op, rhs } => {
+                format!(
+                    "{}({}): {}",
+                    op,
+                    rhs.value_annotation_str(feature_set),
+                    annotation
+                )
+            }
+        }
+    }
+
+    fn inside_fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Infix { .. } => {
+                write!(f, "(")?;
+                self.fmt(f)?;
+                write!(f, ")")
+            }
+            _ => self.fmt(f),
+        }
+    }
+}
+
+impl Display for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Literal(literal) => literal.fmt(f),
+            Self::Infix { lhs, op, rhs } => {
+                lhs.inside_fmt(f)?;
+                write!(f, " {} ", op)?;
+                rhs.inside_fmt(f)
+            }
+            Self::Prefix { op, rhs } => {
+                Display::fmt(&op, f)?;
+                rhs.inside_fmt(f)
+            }
+        }
+    }
+}
+
+#[derive(PartialEq)]
+enum ExprResult {
+    Bool(bool),
+    Int(i32),
+}
+
+impl Display for ExprResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExprResult::Bool(b) => write!(f, "{}", b),
+            ExprResult::Int(i) => write!(f, "{}", i),
+        }
+    }
+}
+
+impl From<ExprResult> for i32 {
+    fn from(value: ExprResult) -> Self {
+        match value {
+            ExprResult::Bool(b) => b as i32,
+            ExprResult::Int(i) => i,
+        }
+    }
+}
+
+impl TryFrom<ExprResult> for bool {
+    type Error = String;
+
+    fn try_from(value: ExprResult) -> Result<Self, Self::Error> {
+        match value {
+            ExprResult::Bool(b) => Ok(b),
+            ExprResult::Int(_) => Err("integer cannot be converted to bool".to_owned()),
+        }
+    }
+}
+
+pub enum Literal {
+    Feature(Feature),
+    Integer(i32),
+}
+
+impl Display for Literal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Literal::Feature(feat) => Display::fmt(&feat.0, f),
+            Literal::Integer(int) => Display::fmt(&int, f),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum InfixOp {
+    Equal,
+    Lower,
+    Greater,
+    LowEq,
+    GreatEq,
+    Add,
+    Sub,
+    Implies,
+    Equiv,
+    Or,
+    Xor,
+    And,
+}
+
+impl InfixOp {
+    fn evaluate(&self, lhsr: ExprResult, rhsr: ExprResult) -> Result<ExprResult, String> {
+        Ok(match self {
+            InfixOp::Equal => ExprResult::Bool(lhsr == rhsr),
+            InfixOp::Lower => ExprResult::Bool(i32::from(lhsr) < i32::from(rhsr)),
+            InfixOp::Greater => ExprResult::Bool(i32::from(lhsr) > i32::from(rhsr)),
+            InfixOp::LowEq => ExprResult::Bool(i32::from(lhsr) <= i32::from(rhsr)),
+            InfixOp::GreatEq => ExprResult::Bool(i32::from(lhsr) >= i32::from(rhsr)),
+            InfixOp::Add => ExprResult::Int(i32::from(lhsr) + i32::from(rhsr)),
+            InfixOp::Sub => ExprResult::Int(i32::from(lhsr) - i32::from(rhsr)),
+            InfixOp::Implies => ExprResult::Bool(!bool::try_from(lhsr)? || bool::try_from(rhsr)?),
+            InfixOp::Equiv => ExprResult::Bool(bool::try_from(lhsr)? == bool::try_from(rhsr)?),
+            InfixOp::Or => ExprResult::Bool(bool::try_from(lhsr)? || bool::try_from(rhsr)?),
+            InfixOp::Xor => ExprResult::Bool(bool::try_from(lhsr)? ^ bool::try_from(rhsr)?),
+            InfixOp::And => ExprResult::Bool(bool::try_from(lhsr)? && bool::try_from(rhsr)?),
+        })
+    }
+}
+
+impl Display for InfixOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            InfixOp::Equal => write!(f, "=="),
+            InfixOp::Lower => write!(f, "<"),
+            InfixOp::Greater => write!(f, ">"),
+            InfixOp::LowEq => write!(f, "<="),
+            InfixOp::GreatEq => write!(f, ">="),
+            InfixOp::Add => write!(f, "+"),
+            InfixOp::Sub => write!(f, "-"),
+            InfixOp::Implies => write!(f, "=>"),
+            InfixOp::Equiv => write!(f, "<=>"),
+            InfixOp::Or => write!(f, "|"),
+            InfixOp::Xor => write!(f, "^"),
+            InfixOp::And => write!(f, "&"),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum PrefixOp {
+    Not,
+    Neg,
+}
+
+impl PrefixOp {
+    fn evaluate(&self, rhsr: ExprResult) -> Result<ExprResult, String> {
+        Ok(match self {
+            PrefixOp::Not => ExprResult::Bool(!bool::try_from(rhsr)?),
+            PrefixOp::Neg => ExprResult::Int(-i32::from(rhsr)),
+        })
+    }
+}
+
+impl Display for PrefixOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrefixOp::Not => write!(f, "!"),
+            PrefixOp::Neg => write!(f, "-"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rules::expr::InfixOp::*;
+    use crate::{
+        rules::{expr::Literal, Expr},
+        types::Feature,
+    };
+    use std::collections::HashSet;
+
+    #[test]
+    fn lazy_eval_avoids_err() {
+        let a = Expr::Literal(Literal::Feature(Feature("A".to_owned())));
+        let b = Expr::Literal(Literal::Feature(Feature("B".to_owned())));
+        let c = Expr::Literal(Literal::Feature(Feature("C".to_owned())));
+        let expr = a.infix(Implies, b.infix(Add, c));
+        let ans = expr.eval(&HashSet::from_iter([&Feature("B".to_owned())]));
+        assert!(ans.is_ok_and(|a| a));
+    }
+
+    #[test]
+    fn nonlazy_eval_produces_err() {
+        let a = Expr::Literal(Literal::Feature(Feature("A".to_owned())));
+        let b = Expr::Literal(Literal::Feature(Feature("B".to_owned())));
+        let c = Expr::Literal(Literal::Feature(Feature("C".to_owned())));
+        let expr = a.infix(Implies, b.infix(Add, c));
+        let ans = expr.eval(&HashSet::from_iter([&Feature("A".to_owned())]));
+        assert!(ans.is_err());
+        assert_eq!(
+            "integer cannot be converted to bool: (A: true) => ((B: false) + (C: false): 0): ERR",
+            ans.err().unwrap()
+        );
+    }
+}

--- a/src/rules/expr.rs
+++ b/src/rules/expr.rs
@@ -1,3 +1,4 @@
+use super::parser::parse_expr;
 use crate::types::Feature;
 use std::{collections::HashSet, fmt::Debug, fmt::Display};
 
@@ -15,6 +16,10 @@ pub enum Expr {
 }
 
 impl Expr {
+    pub fn new(expr: &str) -> Self {
+        parse_expr(expr)
+    }
+
     pub fn infix(self, op: InfixOp, rhs: Self) -> Self {
         Self::Infix {
             lhs: Box::new(self),

--- a/src/rules/parser.rs
+++ b/src/rules/parser.rs
@@ -1,0 +1,124 @@
+use super::expr::{Expr, InfixOp, PrefixOp};
+use crate::rules::expr::Literal;
+use crate::types::Feature;
+use pest::{iterators::Pairs, pratt_parser::PrattParser, Parser};
+use rule_parser::Rule as ParserRule;
+use rule_parser::RuleParser;
+
+mod rule_parser {
+    use pest_derive::Parser;
+
+    #[derive(Parser)]
+    #[grammar = "rules/rule_grammar.pest"]
+    pub struct RuleParser;
+}
+
+lazy_static::lazy_static! {
+    static ref PRATT_PARSER: PrattParser<ParserRule> = {
+        use pest::pratt_parser::{Assoc::*, Op};
+        use ParserRule::*;
+
+        // Precedence is defined lowest to highest
+        PrattParser::new()
+        .op(Op::infix(equal, Left))
+        .op(Op::infix(lower, Left) | Op::infix(greater, Left) | Op::infix(loweq, Left) | Op::infix(greateq, Left))
+        .op(Op::infix(add, Left) | Op::infix(sub, Left))
+        .op(Op::infix(implied, Left))
+        .op(Op::infix(equiv, Left))
+        .op(Op::infix(or, Left))
+        .op(Op::infix(xor, Left))
+        .op(Op::infix(and, Left))
+        .op(Op::prefix(not) | Op::prefix(neg))
+    };
+}
+
+fn parse_recur_expr(pairs: Pairs<ParserRule>) -> Expr {
+    PRATT_PARSER
+        .map_primary(|primary| match primary.as_rule() {
+            ParserRule::featname | ParserRule::simple_featname => {
+                Expr::Literal(Literal::Feature(Feature(primary.as_str().to_owned())))
+            }
+            ParserRule::integer => {
+                Expr::Literal(Literal::Integer(primary.as_str().parse().unwrap()))
+            }
+            ParserRule::recur_expr => parse_recur_expr(primary.into_inner()),
+            rule => unreachable!("Expr::parse expected primary, found {:?}", rule),
+        })
+        .map_infix(|lhs, op, rhs| {
+            let op = match op.as_rule() {
+                ParserRule::and => InfixOp::And,
+                ParserRule::xor => InfixOp::Xor,
+                ParserRule::or => InfixOp::Or,
+                ParserRule::equiv => InfixOp::Equiv,
+                ParserRule::implied => InfixOp::Implies,
+                ParserRule::add => InfixOp::Add,
+                ParserRule::sub => InfixOp::Sub,
+                ParserRule::lower => InfixOp::Lower,
+                ParserRule::greater => InfixOp::Greater,
+                ParserRule::loweq => InfixOp::LowEq,
+                ParserRule::greateq => InfixOp::GreatEq,
+                ParserRule::equal => InfixOp::Equal,
+                rule => unreachable!("Expr::parse expected infix operation, found {:?}", rule),
+            };
+            lhs.infix(op, rhs)
+        })
+        .map_prefix(|op, rhs| {
+            let op = match op.as_rule() {
+                ParserRule::not => PrefixOp::Not,
+                ParserRule::neg => PrefixOp::Neg,
+                rule => unreachable!("Expr::parse expected prefix operation, found {:?}", rule),
+            };
+            rhs.prefix(op)
+        })
+        .parse(pairs)
+}
+
+pub fn parse_expr(input: &str) -> Expr {
+    parse_recur_expr(
+        RuleParser::parse(ParserRule::expr, input)
+            .unwrap()
+            .next()
+            .unwrap()
+            .into_inner(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_expr;
+    use crate::types::Feature;
+    use std::collections::HashSet;
+
+    #[test]
+    fn parser() {
+        let expr = parse_expr("h_a | c4 & (AB => std)");
+        assert_eq!("h_a | (c4 & (AB => std))", format!("{}", expr));
+        let h_a = Feature("h_a".to_owned());
+        let c4 = Feature("c4".to_owned());
+        let ab = Feature("AB".to_owned());
+        let std = Feature("std".to_owned());
+        assert!(!expr.eval(&HashSet::from([])).unwrap());
+        assert!(!expr.eval(&HashSet::from([&ab])).unwrap());
+        assert!(!expr.eval(&HashSet::from([&std])).unwrap());
+        assert!(!expr.eval(&HashSet::from([&c4, &ab])).unwrap());
+        assert!(!expr.eval(&HashSet::from([&ab, &std])).unwrap());
+        assert!(expr.eval(&HashSet::from([&h_a])).unwrap());
+        assert!(expr.eval(&HashSet::from([&c4])).unwrap());
+        assert!(expr.eval(&HashSet::from([&h_a, &c4])).unwrap());
+        assert!(expr.eval(&HashSet::from([&h_a, &ab])).unwrap());
+        assert!(expr.eval(&HashSet::from([&h_a, &std])).unwrap());
+        assert!(expr.eval(&HashSet::from([&c4, &std])).unwrap());
+        assert!(expr.eval(&HashSet::from([&h_a, &c4, &ab])).unwrap());
+        assert!(expr.eval(&HashSet::from([&h_a, &c4, &std])).unwrap());
+        assert!(expr.eval(&HashSet::from([&h_a, &ab, &std])).unwrap());
+        assert!(expr.eval(&HashSet::from([&c4, &ab, &std])).unwrap());
+        assert!(expr.eval(&HashSet::from([&h_a, &c4, &ab, &std])).unwrap());
+    }
+
+    #[test]
+    fn parse_infixes() {
+        assert_eq!("A <=> B", format!("{}", parse_expr("A <=> B")));
+        assert_eq!("A <= B", format!("{}", parse_expr("'A' <= B")));
+        assert_eq!("1 & B", format!("{}", parse_expr("1 & B")));
+    }
+}

--- a/src/rules/rule_grammar.pest
+++ b/src/rules/rule_grammar.pest
@@ -1,0 +1,28 @@
+// PRATT: prefix* ~ primary ~ postfix* ~ (infix ~ prefix* ~ primary ~ postfix*)*
+expr       = _{ SOI ~ recur_expr ~ EOI }
+recur_expr =  { prefix* ~ primary ~ (infix ~ prefix* ~ primary)* }
+
+primary         = _{ simple_featname | "'" ~ featname ~ "'" | integer | "(" ~ recur_expr ~ ")" }
+simple_featname = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_")* }
+featname        = @{ (ASCII_ALPHANUMERIC | "_" | "-")+ }
+integer         = @{ ASCII_DIGIT+ }
+
+infix   = _{ and | xor | or | equiv | implied | add | sub | loweq | greateq | lower | greater | equal }
+and     =  { "&" }
+xor     =  { "^" }
+or      =  { "|" }
+equiv   =  { "<=>" }
+implied =  { "=>" }
+add     =  { "+" }
+sub     =  { "-" }
+loweq   =  { "<=" }
+greateq =  { ">=" }
+lower   =  { "<" }
+greater =  { ">" }
+equal   =  { "==" }
+
+prefix = _{ not | neg }
+not    =  { "!" }
+neg    =  { "-" }
+
+WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -337,10 +337,16 @@ fn skip_sets_with_always_include() -> Result<(), Box<dyn std::error::Error>> {
         skip_feature_sets = [["A", "B"]]
         always_include_features = ["A"]
     "#;
+    let valid_feature_sets = vec![
+        vec!["A"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["A", "C", "oDepB"],
+    ];
     test_dummy_crate_setup(
         feats_deps_allfeatssettings_section,
-        vec![],
-        Some("Package testdummy has feature A in both `skip_feature_sets` and `always_include_features`"),
+        valid_feature_sets,
+        None,
     )
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -20,19 +20,15 @@ fn simple() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "C"],
         vec!["A", "oDepB"],
-        vec!["B", "C"],
-        vec!["B", "oDepB"],
         vec!["C", "oDepB"],
         vec!["A", "B", "C"],
         vec!["A", "B", "oDepB"],
         vec!["A", "C", "oDepB"],
-        vec!["B", "C", "oDepB"],
         vec!["A", "B", "C", "oDepB"],
     ];
     test_dummy_crate_setup(
@@ -63,11 +59,9 @@ fn skip_sets_1() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "oDepB"],
-        vec!["B", "oDepB"],
         vec!["A", "B", "oDepB"],
     ];
     test_dummy_crate_setup(
@@ -98,14 +92,11 @@ fn skip_sets_2() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "C"],
         vec!["A", "oDepB"],
-        vec!["B", "C"],
-        vec!["B", "oDepB"],
         vec!["A", "B", "C"],
         vec!["A", "B", "oDepB"],
     ];
@@ -137,14 +128,11 @@ fn skip_sets_3() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "C"],
         vec!["A", "oDepB"],
-        vec!["B", "C"],
-        vec!["B", "oDepB"],
         vec!["C", "oDepB"],
         vec!["A", "B", "C"],
         vec!["A", "B", "oDepB"],
@@ -176,11 +164,9 @@ fn skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["A", "B"],
         vec!["A", "C"],
-        vec!["B", "C"],
         vec!["A", "B", "C"],
     ];
     test_dummy_crate_setup(
@@ -233,11 +219,9 @@ fn denylist() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "oDepB"],
-        vec!["B", "oDepB"],
         vec!["A", "B", "oDepB"],
     ];
     test_dummy_crate_setup(
@@ -267,19 +251,15 @@ fn extra_feats() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "C"],
         vec!["A", "oDepB"],
-        vec!["B", "C"],
-        vec!["B", "oDepB"],
         vec!["C", "oDepB"],
         vec!["A", "B", "C"],
         vec!["A", "B", "oDepB"],
         vec!["A", "C", "oDepB"],
-        vec!["B", "C", "oDepB"],
         vec!["A", "B", "C", "oDepB"],
     ];
     test_dummy_crate_setup(
@@ -367,7 +347,7 @@ fn allowlist_with_skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
         skip_optional_dependencies = true
         allowlist = ["A", "B", "oDepB"]
     "#;
-    let valid_feature_sets = vec![vec![], vec!["A"], vec!["B"], vec!["A", "B"]];
+    let valid_feature_sets = vec![vec![], vec!["A"], vec!["A", "B"]];
     test_dummy_crate_setup(
         feats_deps_allfeatssettings_section,
         valid_feature_sets,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -355,6 +355,26 @@ fn allowlist_with_skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
     )
 }
 
+#[test]
+fn conflicting_rules() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+[features]
+A = []
+B = ["A"]
+C = ["dep:optDepC"]
+
+[dependencies]
+fixDepA = {path = "fixDepA"}
+oDepB = {path = "optDepB", package = "optDepB", optional = true}
+optDepC = {path = "optDepC", optional = true}
+
+[package.metadata.cargo-all-features]
+skip_feature_sets = [["A", "B"]]
+always_include_features = ["B"]
+"#;
+    test_dummy_crate_setup(feats_deps_allfeatssettings_section, vec![], None)
+}
+
 fn cargo_dep_setup(
     dep_name: &str,
     cwd: &std::path::Path,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,471 @@
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use regex::Regex;
+use std::process::Command;
+
+#[test]
+fn simple() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["B", "C"],
+        vec!["B", "oDepB"],
+        vec!["C", "oDepB"],
+        vec!["A", "B", "C"],
+        vec!["A", "B", "oDepB"],
+        vec!["A", "C", "oDepB"],
+        vec!["B", "C", "oDepB"],
+        vec!["A", "B", "C", "oDepB"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn skip_sets_1() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        skip_feature_sets = [
+            ["C"],
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "oDepB"],
+        vec!["B", "oDepB"],
+        vec!["A", "B", "oDepB"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn skip_sets_2() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        skip_feature_sets = [
+            ["oDepB", "C"],
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["B", "C"],
+        vec!["B", "oDepB"],
+        vec!["A", "B", "C"],
+        vec!["A", "B", "oDepB"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn skip_sets_3() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        skip_feature_sets = [
+            ["oDepB", "B", "C"],
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["B", "C"],
+        vec!["B", "oDepB"],
+        vec!["C", "oDepB"],
+        vec!["A", "B", "C"],
+        vec!["A", "B", "oDepB"],
+        vec!["A", "C", "oDepB"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        skip_optional_dependencies = true
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["B", "C"],
+        vec!["A", "B", "C"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn allowlist() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        allowlist = ["A", "oDepB"]
+    "#;
+    let valid_feature_sets = vec![vec![], vec!["A"], vec!["oDepB"], vec!["A", "oDepB"]];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn denylist() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        denylist = ["C"]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "oDepB"],
+        vec!["B", "oDepB"],
+        vec!["A", "B", "oDepB"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn extra_feats() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        skip_optional_dependencies = true
+        extra_features = ["oDepB"]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["B", "C"],
+        vec!["B", "oDepB"],
+        vec!["C", "oDepB"],
+        vec!["A", "B", "C"],
+        vec!["A", "B", "oDepB"],
+        vec!["A", "C", "oDepB"],
+        vec!["B", "C", "oDepB"],
+        vec!["A", "B", "C", "oDepB"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn always_include() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        #skip_optional_dependencies = true
+        denylist = ["C"]
+        always_include_features = ["A"]
+    "#;
+    let valid_feature_sets = vec![
+        vec!["A"],
+        vec!["A", "B"],
+        vec!["A", "oDepB"],
+        vec!["A", "B", "oDepB"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn skip_sets_with_always_include() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        skip_feature_sets = [["A", "B"]]
+        always_include_features = ["A"]
+    "#;
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        vec![],
+        Some("Package testdummy has feature A in both `skip_feature_sets` and `always_include_features`"),
+    )
+}
+
+#[test]
+fn allowlist_with_skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
+
+        [package.metadata.cargo-all-features]
+        skip_optional_dependencies = true
+        allowlist = ["A", "B", "oDepB"]
+    "#;
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        vec![],
+        Some("Package testdummy has both `allowlist` and `skip_optional_dependencies` keys"),
+    )
+}
+
+fn cargo_dep_setup(
+    dep_name: &str,
+    cwd: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("new").arg(dep_name).current_dir(cwd);
+    cmd.output()?;
+    Ok(())
+}
+
+trait NormStr
+where
+    Self: Sized,
+{
+    const DELIMS: [&'static str; 3] = ["), (", " ", "/"];
+    const PREFIX: [&'static str; 3] = ["(", "", ""];
+    const POSTFIX: [&'static str; 3] = [")", "", ""];
+    fn normalize(self) -> String {
+        self.depthwise_normalize(0)
+    }
+
+    fn depthwise_normalize(self, depth: usize) -> String;
+}
+
+impl<T> NormStr for Vec<T>
+where
+    T: NormStr + std::fmt::Debug,
+{
+    fn depthwise_normalize(self, depth: usize) -> String {
+        let mut v: Vec<_> = self
+            .into_iter()
+            .map(|e| e.depthwise_normalize(depth + 1))
+            .collect();
+        v.sort();
+        Self::PREFIX[depth].to_owned() + &v.join(Self::DELIMS[depth]) + Self::POSTFIX[depth]
+    }
+}
+
+impl NormStr for &str {
+    fn depthwise_normalize(self, _depth: usize) -> String {
+        self.to_owned()
+    }
+}
+
+fn get_tested_feature_sets_from_output(stdout: &str) -> Vec<Vec<&str>> {
+    let re = Regex::new(r"(?m)^.*Testing.*crate=testdummy features=\[(.*)\]$").unwrap();
+
+    let mut ans = vec![];
+    for (_, [comma_sep_features]) in re.captures_iter(stdout).map(|c| c.extract()) {
+        ans.push(comma_sep_features.split(',').collect());
+    }
+    ans
+}
+
+fn test_dummy_crate_setup(
+    feats_deps_allfeatssettings_section: &str,
+    valid_feature_sets: Vec<Vec<&str>>,
+    expected_error: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp = assert_fs::TempDir::new()?;
+    println!("{:?}", temp.path());
+    cargo_dep_setup("fixDepA", temp.path())?;
+    cargo_dep_setup("optDepB", temp.path())?;
+    cargo_dep_setup("optDepC", temp.path())?;
+    let cargotoml = temp.child("Cargo.toml");
+    cargotoml.write_str(&format!(
+        r#"
+        [package]
+        name = "testdummy"
+        version = "0.1.0"
+        {feats_deps_allfeatssettings_section}
+        "#
+    ))?;
+    temp.child("src/main.rs").touch()?;
+
+    let mut cmd = Command::cargo_bin("cargo-test-all-features")?;
+    cmd.arg("test-all-features");
+    cmd.current_dir(temp.path());
+
+    cmd.env("CARGO_INCREMENTAL", "0");
+    cmd.env("RUSTFLAGS", "-Cinstrument-coverage");
+    cmd.env(
+        "LLVM_PROFILE_FILE",
+        "/home/david/code/github/cargo-all-features/target/profraw/cargo-test-%p-%m.profraw",
+    );
+
+    if let Some(err_msg) = expected_error {
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains(err_msg));
+    } else {
+        let stdout = String::from_utf8(cmd.assert().success().get_output().stdout.clone()).unwrap();
+        let produced_feat_sets = get_tested_feature_sets_from_output(&stdout);
+        assert_eq!(
+            valid_feature_sets.normalize(),
+            produced_feat_sets.normalize()
+        );
+    }
+    temp.close()?;
+    Ok(())
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -358,21 +358,219 @@ fn allowlist_with_skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn conflicting_rules() -> Result<(), Box<dyn std::error::Error>> {
     let feats_deps_allfeatssettings_section = r#"
-[features]
-A = []
-B = ["A"]
-C = ["dep:optDepC"]
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
 
-[dependencies]
-fixDepA = {path = "fixDepA"}
-oDepB = {path = "optDepB", package = "optDepB", optional = true}
-optDepC = {path = "optDepC", optional = true}
+        [dependencies]
+        fixDepA = {path = "fixDepA"}
+        oDepB = {path = "optDepB", package = "optDepB", optional = true}
+        optDepC = {path = "optDepC", optional = true}
 
-[package.metadata.cargo-all-features]
-skip_feature_sets = [["A", "B"]]
-always_include_features = ["B"]
-"#;
+        [package.metadata.cargo-all-features]
+        skip_feature_sets = [["A", "B"]]
+        always_include_features = ["B"]
+    "#;
     test_dummy_crate_setup(feats_deps_allfeatssettings_section, vec![], None)
+}
+
+#[test]
+fn issue_42() -> Result<(), Box<dyn std::error::Error>> {
+    // example taken from issue #42
+    // https://github.com/frewsxcv/cargo-all-features/issues/42
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        curl-backend = []
+        reqwest-backend = []
+        reqwest-default-tls = ["reqwest-backend"]
+        reqwest-rustls-tls = ["reqwest-backend"]
+
+        [package.metadata.cargo-all-features]
+        rules = [
+            "'curl-backend'|'reqwest-backend'",
+            "'reqwest-backend'=>'reqwest-default-tls'|'reqwest-rustls-tls'",
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec!["reqwest-backend", "reqwest-default-tls"],
+        vec!["reqwest-backend", "reqwest-rustls-tls"],
+        vec![
+            "reqwest-backend",
+            "reqwest-default-tls",
+            "reqwest-rustls-tls",
+        ],
+        vec!["curl-backend"],
+        vec!["curl-backend", "reqwest-backend", "reqwest-default-tls"],
+        vec!["curl-backend", "reqwest-backend", "reqwest-rustls-tls"],
+        vec![
+            "curl-backend",
+            "reqwest-backend",
+            "reqwest-default-tls",
+            "reqwest-rustls-tls",
+        ],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn readme_rules() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = []
+        C = []
+        foo-bar = []
+        foo-bar_baz = []
+
+        [package.metadata.cargo-all-features]
+        rules = [
+            "A + B + C == 1",  # exactly one of the three features A, B, C is enabled
+            "A + B + C >= 1",  # at least one of the three is enabled
+            "A => (B|C)",  # if package A is enabled, at least one of B or C needs to be enabled too
+            "'foo-bar'",  # the feature set must contain feature foo-bar, use '' quotation for feature names with hyphens
+            """((A => (B|C)) <=> (A+C==1)) \
+            | !'foo-bar_baz' """  # expressions can be arbitrarily nested
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec!["B", "foo-bar"],
+        vec!["C", "foo-bar"],
+        vec!["C", "foo-bar", "foo-bar_baz"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn newline_expr() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = []
+        C = ["A"]
+        D = ["A"]
+
+        [package.metadata.cargo-all-features]
+        rules = [
+            """A + B
+        +C>0
+            ""","A+B<2"
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec!["A"],
+        vec!["B"],
+        vec!["A", "C"],
+        vec!["A", "D"],
+        vec!["A", "C", "D"],
+    ];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )
+}
+
+#[test]
+fn lazy_eval_expr() -> Result<(), Box<dyn std::error::Error>> {
+    // B depends on A, that rule is evaluated before the manually specified rules.
+    // The manually specified rule is valid on the LHS of `=>` and produces always false.
+    // Therefore, the RHS never gets evaluated. If it would, it would break, as the RHS evaluates to an int instead of a bool.
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+
+        [package.metadata.cargo-all-features]
+        rules = [
+            "!(B=>A) => (A+B)"
+        ]
+    "#;
+    let valid_feature_sets = vec![vec![""], vec!["A"], vec!["A", "B"]];
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        valid_feature_sets,
+        None,
+    )?;
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = ["A"]
+
+        [package.metadata.cargo-all-features]
+        rules = [
+            "(B=>A) => (A+B)&A|B"
+        ]
+    "#;
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        vec![],
+        Some("integer cannot be converted to bool: ((B: false) => (A: false): true) => ((((A: false) + (B: false): 0) & (A: false): ERR) | (B: false): ERR): ERR")
+    )
+}
+
+#[test]
+fn expr_err_reporting() -> Result<(), Box<dyn std::error::Error>> {
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = []
+        C = ["A"]
+        D = ["A"]
+
+        [package.metadata.cargo-all-features]
+        rules = [
+            "A&B",
+            "A+B+C"
+        ]
+    "#;
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        vec![],
+        Some("provided rule returned integer 2 instead of a boolean: ((A: true) + (B: true): 2) + (C: false): 2"),
+    )?;
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = []
+        C = ["A"]
+        D = ["A"]
+
+        [package.metadata.cargo-all-features]
+        rules = [
+            "A+B+C|(D=>B)"
+        ]
+    "#;
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        vec![],
+        Some("provided rule returned integer 1 instead of a boolean: ((A: false) + (B: false): 0) + ((C: false) | ((D: false) => (B: false): true): true): 1"),
+    )?;
+    let feats_deps_allfeatssettings_section = r#"
+        [features]
+        A = []
+        B = []
+        C = ["A"]
+        D = ["A"]
+
+        [package.metadata.cargo-all-features]
+        rules = [
+            "A+B+C|(D+B)"
+        ]
+    "#;
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        vec![],
+        Some("integer cannot be converted to bool: ((A: false) + (B: false): 0) + ((C: false) | ((D: false) + (B: false): 0): ERR): ERR"),
+    )
 }
 
 fn cargo_dep_setup(

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -372,7 +372,14 @@ fn conflicting_rules() -> Result<(), Box<dyn std::error::Error>> {
         skip_feature_sets = [["A", "B"]]
         always_include_features = ["B"]
     "#;
-    test_dummy_crate_setup(feats_deps_allfeatssettings_section, vec![], None)
+    test_dummy_crate_setup(
+        feats_deps_allfeatssettings_section,
+        vec![],
+        Some(
+            "no feature set validates against the given rules: \
+            initial #sets 16 -> always_include_features (8/16) -> implication:B (4/8) -> conflict:A,B (0/4)"
+        ),
+    )
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -361,10 +361,11 @@ fn allowlist_with_skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
         skip_optional_dependencies = true
         allowlist = ["A", "B", "oDepB"]
     "#;
+    let valid_feature_sets = vec![vec![], vec!["A"], vec!["B"], vec!["A", "B"]];
     test_dummy_crate_setup(
         feats_deps_allfeatssettings_section,
-        vec![],
-        Some("Package testdummy has both `allowlist` and `skip_optional_dependencies` keys"),
+        valid_feature_sets,
+        None,
     )
 }
 


### PR DESCRIPTION
The first few commits add integration tests and minor refactoring.
Then there is one larger commit, also just doing refactoring, but using rule-based abstraction for resolving valid feature sets. The rules are constructed from nested logical expressions.
The following commit makes us of this, implements a rule parser on top, which allows us to specify arbitrary rule expressions for filtering the set of feature combinations to try out. I link a few issues that can be handled nicely by these changes, and any future requests for strange feature dependencies should be covered by this.
Finally, I added some more code to give an informing error output in case the set of valid feature sets is empty, so that the user can more easily identify the conflicting rules.

Fixes #25.
Fixes #43.
Fixes #42.
Fixes #12.