### PR TITLE
Add integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,18 +61,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f070617a68e5c2ed5d06ee8dd620ee18fb72b99f6c094bed34cf8ab07c875b48"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "bstr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8042c26c77e5bd6897a7358e0abb3ec412ed126d826988135653fc669263899d"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "cargo-all-features"
 version = "1.9.0"
 dependencies = [
+ "assert_cmd",
+ "assert_fs",
  "clap",
  "itertools",
  "json",
+ "predicates",
+ "regex",
  "termcolor",
 ]
 
@@ -72,6 +138,12 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -121,6 +193,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +232,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +287,23 @@ name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "is-terminal"
@@ -186,6 +332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,10 +350,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
+name = "log"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memchr"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "predicates"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -222,17 +432,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "regex"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
 name = "rustix"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
 
 [[package]]
 name = "strsim"
@@ -252,12 +515,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -271,6 +563,25 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,9 @@ json = "0.12"
 itertools = "0.10"
 termcolor = "1"
 clap = { version = "4.3.19", features = ["derive"] }
+
+[dev-dependencies]
+assert_cmd = "2.0.11"
+predicates = "3.0.3"
+assert_fs = "1.0.13"
+regex = "1.9.4"

--- a/ci/test_and_coverage.bash
+++ b/ci/test_and_coverage.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+pushd $SCRIPT_DIR/..
+
+rm target/profraw/cargo-test-*.profraw
+CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='target/profraw/cargo-test-%p-%m.profraw' cargo test
+
+rm -rf target/coverage
+grcov target/profraw/. --binary-path ./target/debug/ -s . -t html --branch --ignore-not-existing -o target/coverage/html
+
+popd
+
+echo "Open target/coverage/html/index.html in a browser to view the coverage report!"

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -1,0 +1,177 @@
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+use regex::Regex;
+use std::process::Command;
+
+#[test]
+fn simple() -> Result<(), Box<dyn std::error::Error>> {
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["B", "C"],
+        vec!["B", "oDepB"],
+        vec!["C", "oDepB"],
+        vec!["A", "B", "C"],
+        vec!["A", "B", "oDepB"],
+        vec!["A", "C", "oDepB"],
+        vec!["B", "C", "oDepB"],
+        vec!["A", "B", "C", "oDepB"],
+    ];
+    test_settings("", valid_feature_sets, None)
+}
+
+/*
+The NormStr trait provides a normalize method which produces a string representation from itself.
+The normalization in these test cases refers to the order of features in lists. The order shall be ignored, therefor
+the normalization produces the same string output for differently ordered sets containing the same elements.
+The DELIMS, PREFIX, and POSTFIX just provide formating guides for a different list-depth.
+E.g. [[A,B], [C,D]] would produce the string (A B), (C D).
+*/
+trait NormStr
+where
+    Self: Sized,
+{
+    const DELIMS: [&'static str; 3] = ["), (", " ", "/"];
+    const PREFIX: [&'static str; 3] = ["(", "", ""];
+    const POSTFIX: [&'static str; 3] = [")", "", ""];
+    fn normalize(self) -> String {
+        self.depthwise_normalize(0)
+    }
+
+    fn depthwise_normalize(self, depth: usize) -> String;
+}
+
+impl<T> NormStr for Vec<T>
+where
+    T: NormStr + std::fmt::Debug,
+{
+    fn depthwise_normalize(self, depth: usize) -> String {
+        let mut v: Vec<_> = self
+            .into_iter()
+            .map(|e| e.depthwise_normalize(depth + 1))
+            .collect();
+        v.sort();
+        Self::PREFIX[depth].to_owned() + &v.join(Self::DELIMS[depth]) + Self::POSTFIX[depth]
+    }
+}
+
+impl NormStr for &str {
+    fn depthwise_normalize(self, _depth: usize) -> String {
+        self.to_owned()
+    }
+}
+
+/*
+Given a path for the crate (cwd) and a dependency name,
+this function creates a local dummy crate which can be used as dependency,
+using the path attribute in Cargo.toml.
+E.g.
+[dependencies]
+dep_name = {path="dep_name"}
+*/
+fn cargo_dep_setup(
+    dep_name: &str,
+    cwd: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("new").arg(dep_name).current_dir(cwd);
+    cmd.output()?;
+    Ok(())
+}
+
+/*
+Using cargo-all-features produces an output of each test or build with a headline,
+denoting the crate and activated features, e.g. Testing crate=testdummy features=[A,B].
+This function expects such a output and filters all the feature sets which were discovered in the output.
+*/
+fn get_tested_feature_sets_from_output(stdout: &str) -> Vec<Vec<&str>> {
+    let re = Regex::new(r"(?m)^.*Testing.*crate=testdummy features=\[(.*)\]$").unwrap();
+
+    let mut ans = vec![];
+    for (_, [comma_sep_features]) in re.captures_iter(stdout).map(|c| c.extract()) {
+        ans.push(comma_sep_features.split(',').collect());
+    }
+    ans
+}
+
+/*
+Setup a compilable dummy crate with no implementation and return the path to this crate layout.
+*/
+fn dummy_crate_setup(settings: &str) -> Result<assert_fs::TempDir, Box<dyn std::error::Error>> {
+    let temp = assert_fs::TempDir::new()?;
+    cargo_dep_setup("fixDepA", temp.path())?;
+    cargo_dep_setup("optDepB", temp.path())?;
+    cargo_dep_setup("optDepC", temp.path())?;
+    let cargotoml = temp.child("Cargo.toml");
+    cargotoml.write_str(&format!(
+        r#"
+        [package]
+        name = "testdummy"
+        version = "0.1.0"
+
+        [features]
+        A = []
+        B = ["A"]
+        C = ["dep:optDepC"]
+
+        [dependencies]
+        fixDepA = {{path = "fixDepA"}}
+        oDepB = {{path = "optDepB", package = "optDepB", optional = true}}
+        optDepC = {{path = "optDepC", optional = true}}
+
+        [package.metadata.cargo-all-features]
+        {settings}
+        "#
+    ))?;
+    temp.child("src/main.rs").touch()?;
+    Ok(temp)
+}
+
+/*
+Test the given settings for cargo-all-features.
+If an error message is provided, expect cargo test-all-features to fail with this message.
+Otherwise expect the normalized set of feature sets to be the same as the given ground truth input.
+*/
+fn test_settings(
+    settings: &str,
+    valid_feature_sets: Vec<Vec<&str>>,
+    expected_error: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let temp = dummy_crate_setup(settings)?;
+    let mut cmd = Command::cargo_bin("cargo-test-all-features")?;
+    cmd.arg("test-all-features");
+    cmd.current_dir(temp.path());
+
+    // add flags for producing also a coverage report, see ci/test_and_coverage.bash
+    cmd.env("CARGO_INCREMENTAL", "0");
+    cmd.env("RUSTFLAGS", "-Cinstrument-coverage");
+    cmd.env(
+        "LLVM_PROFILE_FILE",
+        format!(
+            "{}/target/profraw/cargo-test-%p-%m.profraw",
+            std::env::current_dir()?.display()
+        ),
+    );
+
+    if let Some(err_msg) = expected_error {
+        cmd.assert()
+            .failure()
+            .stderr(predicate::str::contains(err_msg));
+    } else {
+        let stdout = String::from_utf8(cmd.assert().success().get_output().stdout.clone()).unwrap();
+        let produced_feat_sets = get_tested_feature_sets_from_output(&stdout);
+        assert_eq!(
+            valid_feature_sets.normalize(),
+            produced_feat_sets.normalize()
+        );
+    }
+    temp.close()?;
+    Ok(())
+}

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -27,6 +27,190 @@ fn simple() -> Result<(), Box<dyn std::error::Error>> {
     test_settings("", valid_feature_sets, None)
 }
 
+#[test]
+fn skip_sets_1() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        skip_feature_sets = [
+            ["C"],
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "oDepB"],
+        vec!["B", "oDepB"],
+        vec!["A", "B", "oDepB"],
+    ];
+    test_settings(settings, valid_feature_sets, None)
+}
+
+#[test]
+fn skip_sets_2() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        skip_feature_sets = [
+            ["oDepB", "C"],
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["B", "C"],
+        vec!["B", "oDepB"],
+        vec!["A", "B", "C"],
+        vec!["A", "B", "oDepB"],
+    ];
+    test_settings(settings, valid_feature_sets, None)
+}
+
+#[test]
+fn skip_sets_3() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        skip_feature_sets = [
+            ["oDepB", "B", "C"],
+        ]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["B", "C"],
+        vec!["B", "oDepB"],
+        vec!["C", "oDepB"],
+        vec!["A", "B", "C"],
+        vec!["A", "B", "oDepB"],
+        vec!["A", "C", "oDepB"],
+    ];
+    test_settings(settings, valid_feature_sets, None)
+}
+
+#[test]
+fn skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        skip_optional_dependencies = true
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["B", "C"],
+        vec!["A", "B", "C"],
+    ];
+    test_settings(settings, valid_feature_sets, None)
+}
+
+#[test]
+fn allowlist() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        allowlist = ["A", "oDepB"]
+    "#;
+    let valid_feature_sets = vec![vec![], vec!["A"], vec!["oDepB"], vec!["A", "oDepB"]];
+    test_settings(settings, valid_feature_sets, None)
+}
+
+#[test]
+fn denylist() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        denylist = ["C"]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "oDepB"],
+        vec!["B", "oDepB"],
+        vec!["A", "B", "oDepB"],
+    ];
+    test_settings(settings, valid_feature_sets, None)
+}
+
+#[test]
+fn extra_feats() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        skip_optional_dependencies = true
+        extra_features = ["oDepB"]
+    "#;
+    let valid_feature_sets = vec![
+        vec![],
+        vec!["A"],
+        vec!["B"],
+        vec!["C"],
+        vec!["oDepB"],
+        vec!["A", "B"],
+        vec!["A", "C"],
+        vec!["A", "oDepB"],
+        vec!["B", "C"],
+        vec!["B", "oDepB"],
+        vec!["C", "oDepB"],
+        vec!["A", "B", "C"],
+        vec!["A", "B", "oDepB"],
+        vec!["A", "C", "oDepB"],
+        vec!["B", "C", "oDepB"],
+        vec!["A", "B", "C", "oDepB"],
+    ];
+    test_settings(settings, valid_feature_sets, None)
+}
+
+#[test]
+fn always_include() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        #skip_optional_dependencies = true
+        denylist = ["C"]
+        always_include_features = ["A"]
+    "#;
+    let valid_feature_sets = vec![
+        vec!["A"],
+        vec!["A", "B"],
+        vec!["A", "oDepB"],
+        vec!["A", "B", "oDepB"],
+    ];
+    test_settings(settings, valid_feature_sets, None)
+}
+
+#[test]
+fn skip_sets_with_always_include() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        skip_feature_sets = [["A", "B"]]
+        always_include_features = ["A"]
+    "#;
+    test_settings(
+        settings,
+        vec![],
+        Some("Package testdummy has feature A in both `skip_feature_sets` and `always_include_features`"),
+    )
+}
+
+#[test]
+fn allowlist_with_skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
+    let settings = r#"
+        skip_optional_dependencies = true
+        allowlist = ["A", "B", "oDepB"]
+    "#;
+    test_settings(
+        settings,
+        vec![],
+        Some("Package testdummy has both `allowlist` and `skip_optional_dependencies` keys"),
+    )
+}
+
 /*
 The NormStr trait provides a normalize method which produces a string representation from itself.
 The normalization in these test cases refers to the order of features in lists. The order shall be ignored, therefor


### PR DESCRIPTION
This PR adds some first integration tests to provide 100% line coverage of `feature_finder.rs` which is the core logic of this crate.

We only add a few lightweight dev-dependencies, so this has no downstream effect.