### PR TITLE
Consider feature dependencies in test matrix

### DIFF
--- a/src/features_finder.rs
+++ b/src/features_finder.rs
@@ -73,6 +73,10 @@ pub fn fetch_feature_sets(package: &crate::cargo_metadata::Package) -> Vec<Featu
     let max_combination_size = package.max_combination_size.unwrap_or(features.len());
     for n in 0..=max_combination_size {
         'outer: for feature_set in features.iter().combinations(n) {
+            let feature_set: Vec<_> = feature_set
+                .into_iter()
+                .chain(package.always_include_features.iter())
+                .collect();
             'inner: for skip_feature_set in &package.skip_feature_sets {
                 for feature in skip_feature_set.iter() {
                     if !feature_set.contains(&feature) {
@@ -83,13 +87,7 @@ pub fn fetch_feature_sets(package: &crate::cargo_metadata::Package) -> Vec<Featu
                 // skip_feature_set matches: do not add it to feature_sets
                 continue 'outer;
             }
-            feature_sets.push(
-                feature_set
-                    .into_iter()
-                    .chain(package.always_include_features.iter())
-                    .cloned()
-                    .collect(),
-            );
+            feature_sets.push(feature_set.into_iter().cloned().collect());
         }
     }
 

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -9,19 +9,15 @@ fn simple() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "C"],
         vec!["A", "oDepB"],
-        vec!["B", "C"],
-        vec!["B", "oDepB"],
         vec!["C", "oDepB"],
         vec!["A", "B", "C"],
         vec!["A", "B", "oDepB"],
         vec!["A", "C", "oDepB"],
-        vec!["B", "C", "oDepB"],
         vec!["A", "B", "C", "oDepB"],
     ];
     test_settings("", valid_feature_sets, None)
@@ -37,11 +33,9 @@ fn skip_sets_1() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "oDepB"],
-        vec!["B", "oDepB"],
         vec!["A", "B", "oDepB"],
     ];
     test_settings(settings, valid_feature_sets, None)
@@ -57,14 +51,11 @@ fn skip_sets_2() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "C"],
         vec!["A", "oDepB"],
-        vec!["B", "C"],
-        vec!["B", "oDepB"],
         vec!["A", "B", "C"],
         vec!["A", "B", "oDepB"],
     ];
@@ -81,14 +72,11 @@ fn skip_sets_3() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "C"],
         vec!["A", "oDepB"],
-        vec!["B", "C"],
-        vec!["B", "oDepB"],
         vec!["C", "oDepB"],
         vec!["A", "B", "C"],
         vec!["A", "B", "oDepB"],
@@ -105,11 +93,9 @@ fn skip_opt_deps() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["A", "B"],
         vec!["A", "C"],
-        vec!["B", "C"],
         vec!["A", "B", "C"],
     ];
     test_settings(settings, valid_feature_sets, None)
@@ -132,11 +118,9 @@ fn denylist() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "oDepB"],
-        vec!["B", "oDepB"],
         vec!["A", "B", "oDepB"],
     ];
     test_settings(settings, valid_feature_sets, None)
@@ -151,19 +135,15 @@ fn extra_feats() -> Result<(), Box<dyn std::error::Error>> {
     let valid_feature_sets = vec![
         vec![],
         vec!["A"],
-        vec!["B"],
         vec!["C"],
         vec!["oDepB"],
         vec!["A", "B"],
         vec!["A", "C"],
         vec!["A", "oDepB"],
-        vec!["B", "C"],
-        vec!["B", "oDepB"],
         vec!["C", "oDepB"],
         vec!["A", "B", "C"],
         vec!["A", "B", "oDepB"],
         vec!["A", "C", "oDepB"],
-        vec!["B", "C", "oDepB"],
         vec!["A", "B", "C", "oDepB"],
     ];
     test_settings(settings, valid_feature_sets, None)


### PR DESCRIPTION
These two small commits fix #25 in that transitive, or dependent features are considered during the construction of the test matrix. It also closes #43.

Commit message:
Even though cargo activates dependent features automatically, we can reduce
the amount of feature sets when already resolving these dependencies during creation of all feature sets.
We decide to go for the more verbose option, selecting [A, B] over [B] when A is a feature dependency of B.
This allows an easier implementation, as dependency chains C -> B -> A can be verified one by one, and it takes other rules like
skip_feature_sets correctly into account without modification. (see `__nightly` example from #25)

BREAKING CHANGE: As previously feature sets [B], [A,B] were included separatly, now there will only be [A,B] run if A is a dependency of B. The testcase [B] is redundant, as it activates feature A automatically.