### PR TITLE
Add support to execute nextest

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Test crate with all feature flag combinations:
 cargo test-all-features <CARGO TEST FLAGS>
 ```
 
+Test crate with all feature flag combinations using the nextest:
+
+```
+cargo nextest-all-features <NEXTEST OPTIONS> <CARGO TEST FLAGS>
+```
 
 ## Why?
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ enum CargoCli {
     #[command(name = "check-all-features")]
     #[command(alias = "build-all-features")]
     #[command(alias = "test-all-features")]
+    #[command(alias = "nextest-all-features")]
     Subcommand(Cli),
 }
 

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -22,6 +22,12 @@ impl TestRunner {
         let mut command = process::Command::new(&crate::cargo_cmd());
 
         command.arg(cargo_command.get_name());
+
+        // Pass through cargo args
+        for arg in cargo_args {
+            command.arg(arg);
+        }
+
         command.arg("--no-default-features");
 
         let mut features = feature_set
@@ -33,11 +39,6 @@ impl TestRunner {
 
             command.arg("--features");
             command.arg(&features);
-        }
-
-        // Pass through cargo args
-        for arg in cargo_args {
-            command.arg(arg);
         }
 
         TestRunner {
@@ -62,6 +63,7 @@ impl TestRunner {
             CargoCommand::Build => print!("    Building "),
             CargoCommand::Check => print!("    Checking "),
             CargoCommand::Test => print!("     Testing "),
+            CargoCommand::Nextest => print!("  Testing using Nextest"),
         }
         stdout.reset().unwrap();
         println!("crate={} features=[{}]", self.crate_name, self.features);
@@ -86,6 +88,7 @@ pub enum CargoCommand {
     Build,
     Check,
     Test,
+    Nextest,
 }
 
 impl CargoCommand {
@@ -94,6 +97,7 @@ impl CargoCommand {
             CargoCommand::Build => "build",
             CargoCommand::Check => "check",
             CargoCommand::Test => "test",
+            CargoCommand::Nextest => "nextest",
         }
     }
     pub fn get_cli_name(self) -> &'static str {
@@ -101,6 +105,7 @@ impl CargoCommand {
             CargoCommand::Build => "build-all-features",
             CargoCommand::Check => "check-all-features",
             CargoCommand::Test => "test-all-features",
+            CargoCommand::Nextest => "nextest-all-features",
         }
     }
 }

--- a/tests/settings.rs
+++ b/tests/settings.rs
@@ -328,9 +328,31 @@ fn test_settings(
     valid_feature_sets: Vec<Vec<&str>>,
     expected_error: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    test_settings_ex("cargo-test-all-features", vec!["test-all-features"], settings, valid_feature_sets.clone(), expected_error)?;
+    test_settings_ex("cargo-nextest-all-features", vec!["nextest-all-features", "run"], settings, valid_feature_sets.clone(), expected_error)?;
+
+    Ok(())
+}
+
+/*
+Test the given settings for cargo-all-features.
+If an error message is provided, expect cargo test-all-features to fail with this message.
+Otherwise expect the normalized set of feature sets to be the same as the given ground truth input.
+*/
+fn test_settings_ex (
+    test_binary: &str,
+    initial_args: Vec<&str>,
+    settings: &str,
+    valid_feature_sets: Vec<Vec<&str>>,
+    expected_error: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let temp = dummy_crate_setup(settings)?;
-    let mut cmd = Command::cargo_bin("cargo-test-all-features")?;
-    cmd.arg("test-all-features");
+    let mut cmd = Command::cargo_bin(test_binary)?;
+
+    for arg in initial_args {
+        cmd.arg(arg);
+    }
+
     cmd.current_dir(temp.path());
 
     // add flags for producing also a coverage report, see ci/test_and_coverage.bash


### PR DESCRIPTION
Cargo supports cargo test and cargo nextest

This commit provides support of cargo nextest the cargo-all-feature.
Users can simply do
cargo nextest-all-features run <cargo options>
to execute all nextest tests.