### PR TITLE
[Draft] Override config via cli

### DIFF
--- a/src/features_finder.rs
+++ b/src/features_finder.rs
@@ -5,10 +5,14 @@ use crate::{
 use itertools::Itertools;
 use std::collections::HashSet;
 
-pub fn fetch_feature_sets(package: &crate::cargo_metadata::Package) -> Vec<FeatureList> {
+pub fn fetch_feature_sets(
+    package: &crate::cargo_metadata::Package,
+    exclude: &[String],
+) -> Vec<FeatureList> {
     let mut features = FeatureList::default();
 
     let mut denylist_and_alwayses = package.denylist.clone();
+    denylist_and_alwayses.extend(exclude.iter().map(|x| Feature(x.clone())));
     denylist_and_alwayses.extend(package.always_include_features.iter().cloned());
 
     let filter_denylist_and_alwayses = |f: &Feature| !denylist_and_alwayses.contains(f);


### PR DESCRIPTION
It would be nice to override the "exclude" configuration in cargo.toml with cli options.

In my case, I have a `cuda` feature which I'd like to include when I run `cargo-*-all-features` locally, but which cannot be used in CI. Right now, there is no good way to configure this.

I can add `cuda` to a denylist, but it is then excluded in both CI and locally. Override cli args like `exclude` (implemented here) and `include` (not implemented) would make this much easier.

What do you think? What's the best way to implement this?