### PR TITLE
add support for chunking by feature+package sets

### DIFF
--- a/src/cargo_metadata.rs
+++ b/src/cargo_metadata.rs
@@ -23,7 +23,7 @@ fn fetch_cargo_metadata_json() -> Result<String, Box<dyn error::Error>> {
     Ok(String::from_utf8(output.stdout)?)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Dependency {
     pub name: String,
     pub rename: Option<String>,
@@ -44,7 +44,7 @@ impl From<json::JsonValue> for Dependency {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Package {
     pub id: String,
     pub name: String,


### PR DESCRIPTION
This MR adds `--split-by-feature` flag, which affects the chunking mechanism - chunking by crate+feature tuples - which allows for more effective parallelization on CI.

resolves #49

Here's how the output looks when executed on `serde` crate
```
$ cargo check-all-features --n-chunks 4 --chunk 1 --split-by-feature
Running on chunk 1 out of 4 (26 items: serde [<none>], serde [serde_derive], serde [alloc], serde [derive], serde [rc], serde [std], serde [unstable], serde [serde_derive+alloc], serde [serde_derive+derive], serde [serde_derive+rc], serde [serde_derive+std], serde [serde_derive+unstable], serde [alloc+derive], serde [alloc+rc], serde [alloc+std], serde [alloc+unstable], serde [derive+rc], serde [derive+std], serde [derive+unstable], serde [rc+std], serde [rc+unstable], serde [std+unstable], serde [serde_derive+alloc+derive], serde [serde_derive+alloc+rc], serde [serde_derive+alloc+std], serde [serde_derive+alloc+unstable])
     Running check crate=serde features=[]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.29s
     Running check crate=serde features=[serde_derive]
   Compiling proc-macro2 v1.0.103
   Compiling quote v1.0.41
   Compiling unicode-ident v1.0.20
   Compiling serde_derive v1.0.228 (/home/muttley/git/serde/serde_derive)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
   Compiling syn v2.0.108
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.91s
     Running check crate=serde features=[alloc]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.06s
     Running check crate=serde features=[derive]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
     Running check crate=serde features=[rc]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.82s
     Running check crate=serde features=[std]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.01s
     Running check crate=serde features=[unstable]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.47s
     Running check crate=serde features=[serde_derive,alloc]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.42s
     Running check crate=serde features=[serde_derive,derive]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running check crate=serde features=[serde_derive,rc]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running check crate=serde features=[serde_derive,std]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.48s
     Running check crate=serde features=[serde_derive,unstable]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Running check crate=serde features=[alloc,derive]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s
     Running check crate=serde features=[alloc,rc]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.54s
     Running check crate=serde features=[alloc,std]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.59s
     Running check crate=serde features=[alloc,unstable]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.50s
     Running check crate=serde features=[derive,rc]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running check crate=serde features=[derive,std]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s
     Running check crate=serde features=[derive,unstable]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running check crate=serde features=[rc,std]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.57s
     Running check crate=serde features=[rc,unstable]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.24s
     Running check crate=serde features=[std,unstable]
   Compiling serde_core v1.0.228 (/home/muttley/git/serde/serde_core)
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.51s
     Running check crate=serde features=[serde_derive,alloc,derive]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.01s
     Running check crate=serde features=[serde_derive,alloc,rc]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.39s
     Running check crate=serde features=[serde_derive,alloc,std]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s
     Running check crate=serde features=[serde_derive,alloc,unstable]
   Compiling serde v1.0.228 (/home/muttley/git/serde/serde)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s
```