### PR TITLE
Bump to 1.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-all-features"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-all-features"
-version = "1.11.0"
+version = "1.12.0"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 edition = "2021"
 description = "A Cargo subcommand to build and test all feature flag combinations"


### PR DESCRIPTION
In #65 I didn't bump the version, but it's most probably needed to create a new release.