### PR TITLE
remove is_multiple_of, fix Rust 1.80.0 compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-all-features"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-all-features"
-version = "1.12.0"
+version = "1.12.1"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 edition = "2021"
 description = "A Cargo subcommand to build and test all feature flag combinations"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,8 @@ pub fn run() -> Result<(), Box<dyn error::Error>> {
     // we must adjust to deal with the fact that if things are not a perfect multiple,
     // len / n_chunks will end up with an uncounted remainder chunk
     let mut chunk_size = work_items.len() / cli.n_chunks;
-    if !work_items.len().is_multiple_of(cli.n_chunks) {
+    #[allow(clippy::manual_is_multiple_of)]
+    if work_items.len() % cli.n_chunks != 0 {
         chunk_size += 1;
     }
 


### PR DESCRIPTION
fixes #67 