### PR TITLE
bump to 1.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-all-features"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-all-features"
-version = "1.12.0"
+version = "1.12.1"
 authors = ["Corey Farwell <coreyf@rwell.org>"]
 edition = "2021"
 description = "A Cargo subcommand to build and test all feature flag combinations"


### PR DESCRIPTION
With #67 the `1.12.0` version got yanked, though it probably shouldn't be. This MR bumps the version again to `1.12.1`